### PR TITLE
Frontend Revisions/fix authentication layout scroll and background image

### DIFF
--- a/ui/src/assets/images/backgrounds/authentication-grid.svg
+++ b/ui/src/assets/images/backgrounds/authentication-grid.svg
@@ -1,0 +1,41 @@
+<svg width="750" height="900" viewBox="0 0 750 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="750" height="900" fill="#DA3630"/>
+<mask id="mask0_1993_220151" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="750" height="900">
+<rect width="750" height="900" fill="#DA3630"/>
+</mask>
+<g mask="url(#mask0_1993_220151)">
+<path d="M336.922 77.8955H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 154.875H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 231.854H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 308.833H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 385.812H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 462.791H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 539.771H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 616.75H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 693.729H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 770.708H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 847.687H1593.26" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M407.55 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M475.684 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M543.821 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M611.955 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M680.089 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M748.224 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 77.896H1565.85" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 154.875H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 231.854H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 308.833H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 385.812H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 462.792H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 539.771H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 616.75H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 693.729H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 770.708H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M-892 847.687H364.343" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M61.8901 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M130.025 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M198.159 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M266.294 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+<path d="M336.922 0V899.006" stroke="white" stroke-opacity="0.1" stroke-width="1.5"/>
+</g>
+</svg>

--- a/ui/src/layouts/Authentication/Authentication.jsx
+++ b/ui/src/layouts/Authentication/Authentication.jsx
@@ -19,7 +19,7 @@ const AuthenticationHalf = (props) => {
   return (
     <Grid 
       container
-      className={classes.root}
+      className={`${classes.root} no-zoom`}
     >
       {/* SIDE CONTENT */}
       <Grid
@@ -58,7 +58,7 @@ const AuthenticationHalf = (props) => {
       <Grid
         item
         xs={6}
-        className={`${classes.content} ${classes.contentMain}`}
+        className={`${classes.content} ${classes.contentMain} zoom`}
       >
         {/* PRODUCT LOGO */}
         <Box

--- a/ui/src/layouts/Authentication/Authentication.jsx
+++ b/ui/src/layouts/Authentication/Authentication.jsx
@@ -25,7 +25,7 @@ const AuthenticationHalf = (props) => {
       <Grid
         item
         xs={6}
-        className={`${classes.content} ${classes.contentSide}`}
+        className={`${classes.content} ${classes.contentSide} zoom`}
       >
         <Stack className={classes.containerText}>
           {/* TITLE */}

--- a/ui/src/layouts/Authentication/authenticationUseStyles.js
+++ b/ui/src/layouts/Authentication/authenticationUseStyles.js
@@ -1,3 +1,6 @@
+// ASSETS
+import imageAuthenticationGrid from 'assets/images/backgrounds/authentication-grid.svg'
+
 // CONSTANTS
 import { values } from 'constants/values'
 
@@ -15,8 +18,13 @@ const useStyles = makeStyles((theme) => ({
   },
   contentSide: {
     position: 'relative',
-    backgroundColor: theme.palette.primary.main,
+    backgroundImage: `url("${imageAuthenticationGrid}")`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
     borderRight: `3px solid ${theme.palette.common.black}`,
+    maxHeight: '100vh',
+    overflowY: 'hidden',
   },
   containerText: {
     marginTop: 152,

--- a/ui/src/pages/AuthenticationFinish/AuthenticationFinish.jsx
+++ b/ui/src/pages/AuthenticationFinish/AuthenticationFinish.jsx
@@ -55,7 +55,7 @@ const AuthenticationFinish = () => {
     <Stack
       justifyContent='center'
       alignItems='center'
-      className={classes.root}
+      className={`${classes.root} no-zoom`}
     >
       {/* PRODUCT LOGO */}
       <Box

--- a/ui/src/pages/AuthenticationFinish/AuthenticationFinish.jsx
+++ b/ui/src/pages/AuthenticationFinish/AuthenticationFinish.jsx
@@ -68,7 +68,7 @@ const AuthenticationFinish = () => {
       {/* CONTENT CONTAINER */}
       <Stack 
         alignItems='center'
-        className={classes.containerContent}
+        className={`${classes.containerContent} zoom`}
       >
         {/* EMAIL ICON */}
         <Box

--- a/ui/src/pages/AuthenticationFinish/authenticationFinishUseStyles.js
+++ b/ui/src/pages/AuthenticationFinish/authenticationFinishUseStyles.js
@@ -1,3 +1,6 @@
+// ASSETS
+import imageAuthenticationGrid from 'assets/images/backgrounds/authentication-grid.svg'
+
 // CONSTANTS
 import { values } from 'constants/values'
 
@@ -6,6 +9,10 @@ import { makeStyles } from '@mui/styles'
 
 const useStyles = makeStyles((theme) => ({
   root: {
+    backgroundImage: `url("${imageAuthenticationGrid}")`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
     minHeight: '100vh',
     height: '100vh',
     position: 'relative',

--- a/ui/src/pages/AuthenticationFinish/authenticationFinishUseStyles.js
+++ b/ui/src/pages/AuthenticationFinish/authenticationFinishUseStyles.js
@@ -10,9 +10,7 @@ import { makeStyles } from '@mui/styles'
 const useStyles = makeStyles((theme) => ({
   root: {
     backgroundImage: `url("${imageAuthenticationGrid}")`,
-    backgroundSize: 'cover',
-    backgroundPosition: 'center',
-    backgroundRepeat: 'no-repeat',
+    backgroundRepeat: 'repeat',
     minHeight: '100vh',
     height: '100vh',
     position: 'relative',


### PR DESCRIPTION
### **Before**
AuthenticationHalf Layout
<img width="1440" alt="Screen Shot 2022-08-26 at 10 01 39" src="https://user-images.githubusercontent.com/22076215/186811891-4a41cdad-5767-4b43-9339-cc08735de9cb.png">

Authentication Finish Page
<img width="1440" alt="Screen Shot 2022-08-26 at 11 23 13" src="https://user-images.githubusercontent.com/22076215/186811945-f02195d8-3d7c-4e9c-a748-a2e552701ee3.png">

### **After**
AuthenticationHalf Layout
<img width="1440" alt="Screen Shot 2022-08-26 at 11 36 58" src="https://user-images.githubusercontent.com/22076215/186812307-03356cf9-22b0-4477-bb73-63752beae26e.png">

Authentication Finish Sign up & Reset Password
<img width="1440" alt="Screen Shot 2022-08-26 at 12 07 14" src="https://user-images.githubusercontent.com/22076215/186820535-c24cacb2-df78-49c2-8552-ec994405db56.png">

### **General Changes**
1. no scroll on page wrapped by `AuthenticationHalf` layout.
2. add Background Authentication Grid.

### **Detail Changes**
1. remove scroll by adding max-height: 100vh and overflow-y: hidden.
2. add class `zoom` and `no-zoom` on `AuthenticationHalf` and `AuthenticationFinish` .
3. add background authentication grid on `AuthenticationHalf` and `AuthenticationFinish`.