### PR TITLE
Frontend revisions/fix authentication layout size

### DIFF
--- a/ui/src/layouts/Authentication/authenticationUseStyles.js
+++ b/ui/src/layouts/Authentication/authenticationUseStyles.js
@@ -9,7 +9,8 @@ import { makeStyles } from '@mui/styles'
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    minHeight: '100vh',
+    height: '100vh',
+    overflow: 'hidden'
   },
   content: {
     display: 'flex',
@@ -24,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundRepeat: 'no-repeat',
     borderRight: `3px solid ${theme.palette.common.black}`,
     overflowY: 'hidden',
+    height: '100%'
   },
   containerText: {
     marginTop: 152,


### PR DESCRIPTION
### **Before**
scroll on sign in page
<img width="1440" alt="Screen Shot 2022-09-02 at 10 44 14" src="https://user-images.githubusercontent.com/22076215/188048934-a8d5bd5f-42cf-4fc0-af40-863262a8cb99.png">

### **After**
no scroll on sign in page
<img width="1440" alt="Screen Shot 2022-09-02 at 10 43 29" src="https://user-images.githubusercontent.com/22076215/188048957-5135d570-2250-47d3-8f45-004512fb1c89.png">

### **General Changes**
1. make no scroll on `authentication layout`

### **Detail Changes**
1. change style on `authentication style`