### PR TITLE
Frontend features/zoom effect form field

### DIFF
--- a/ui/src/components/Customs/CustomTooltip.jsx
+++ b/ui/src/components/Customs/CustomTooltip.jsx
@@ -27,7 +27,7 @@ const StyledTooltip = styled(({ className, ...props }) => (
 
 const CustomTooltip = (props) => {
   return (
-    <Stack className='neutralize-zoom-tooptip'>
+    <Stack className='neutralize-zoom-tooltip'>
       <StyledTooltip className='no-zoom' {...props}/>
     </Stack>
   )

--- a/ui/src/components/GlobalStyles/GlobalStyles.jsx
+++ b/ui/src/components/GlobalStyles/GlobalStyles.jsx
@@ -90,6 +90,62 @@ const GlobalStyles = () => {
           'body': {
             zoom: values.zoomValue,
           },
+          // AUTOCOMPLETE PURE
+          '.neutralize-zoom-autocomplete': {
+            '& .MuiInputBase-root': {
+              height: '44px !important',
+            },
+            '& .MuiInputBase-input': {
+              zoom: values.zoomValue,
+            },
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderWidth: 1.5,
+            },
+            '& .MuiFormLabel-root': {
+              zoom: values.zoomValue,
+            },
+            '& legend': {
+              zoom: values.zoomValue,
+            },
+            '& .MuiButtonBase-root': {
+              zoom: values.zoomValue,
+            }
+          },
+          '.MuiAutocomplete-popper': {
+            zoom: 1 / values.zoomValue,
+          },
+          '.MuiAutocomplete-popper ul': {
+            zoom: values.zoomValue,
+          },
+          '.MuiAutocomplete-popper li': {
+            zoom: values.zoomValue,
+          },
+          '.neutralize-zoom-select': {
+            '& .MuiSelect-select': {
+              zoom: 1 / values.zoomValue,
+            },
+            '& .MuiChip-root': {
+              zoom: values.zoomValue,
+            }
+          },
+          '.neutralize-zoom-select-menu': {
+            '& .MuiPaper-root': {
+              zoom: 1 / values.zoomValue,
+              width: 'auto',
+            },
+            '& .MuiList-root': {
+              zoom: values.zoomValue,
+            },
+            '& .MuiList-root li': {
+              zoom: values.zoomValue,
+            }
+          },
+          '.neutralize-zoom-sortable': {
+            zoom: 1 / values.zoomValue,
+            '& .sortable-ghost': {
+              zoom: values.zoomValue,
+            },
+          },
           '.neutralize-zoom-menu': {
             '& .MuiPaper-root': {
               zoom: 1 / values.zoomValue,
@@ -98,7 +154,7 @@ const GlobalStyles = () => {
               zoom: values.zoomValue,
             }
           },
-          '.neutralize-zoom-tooptip': {
+          '.neutralize-zoom-tooltip': {
             zoom: 1 / values.zoomValue,
             '& .MuiIconButton-root .MuiSvgIcon-root': {
               zoom: values.zoomValue,

--- a/ui/src/components/GlobalStyles/GlobalStyles.jsx
+++ b/ui/src/components/GlobalStyles/GlobalStyles.jsx
@@ -120,6 +120,15 @@ const GlobalStyles = () => {
           '.MuiAutocomplete-popper li': {
             zoom: values.zoomValue,
           },
+          '.neutralize-dialog-form': {
+            zoom: 1 / values.zoomValue,
+            '& .MuiDialogTitle-root': {
+              zoom: values.zoomValue,
+            },
+            '& .MuiDialogActions-root': {
+              zoom: values.zoomValue,
+            }
+          },
           '.neutralize-zoom-select': {
             '& .MuiSelect-select': {
               zoom: 1 / values.zoomValue,

--- a/ui/src/pages/FillForm/FillForm.jsx
+++ b/ui/src/pages/FillForm/FillForm.jsx
@@ -14,6 +14,7 @@ import { dummyData } from './fillFormConstants'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
+import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 
@@ -42,7 +43,7 @@ const FillForm = () => {
   return (
     <Stack direction='column' alignItems='center' className={`${classes.root} no-zoom`}>
       {/* CONTENT */}
-      <LoadingPaper className={classes.content}>
+      <LoadingPaper className={`${classes.content} zoom`}>
         {/* HEADER */}
         <Stack className={classes.header}>
           <Typography variant='h5' className='fontWeight500'>{dummyData.label}</Typography>
@@ -70,13 +71,15 @@ const FillForm = () => {
       </LoadingPaper>
 
       {/* FOOTER */}
-      <Stack className={classes.footer} direction='row' alignItems='center'>
+      <Stack className={`${classes.footer} zoom`} direction='row' alignItems='center'>
         <Stack flex={1}>
-          <Box
-            component='img'
-            src={logoWorx}
-            className={classes.footerLogo}
-          />
+          <Link href='/'>
+            <Box
+              component='img'
+              src={logoWorx}
+              className={classes.footerLogo}
+            />
+          </Link>
         </Stack>
 
         <Typography

--- a/ui/src/pages/FillForm/InputForm.jsx
+++ b/ui/src/pages/FillForm/InputForm.jsx
@@ -416,7 +416,7 @@ const InputForm = (props) => {
           </Button>)}
 
           <DialogForm
-            classNames={classes.dialogSignature}
+            classNames={`${classes.dialogSignature} neutralize-dialog-form`}
             title='Create Signature'
             handleActionButtonClick={handleSignatureActionButtonClick}
           >

--- a/ui/src/pages/FormsCreateOrEdit/FormFields/FormFields.jsx
+++ b/ui/src/pages/FormsCreateOrEdit/FormFields/FormFields.jsx
@@ -70,7 +70,7 @@ const FormFields = () => {
       <Stack className={classes.listFieldsWrap}>
         {/* SORTABLE */}
         <ReactSortable
-          className={classes.reactSortable}
+          className={`${classes.reactSortable} neutralize-zoom-sortable`}
           animation={200}
           delayOnTouchStart={true}
           delay={2}
@@ -86,7 +86,7 @@ const FormFields = () => {
           {listFields.map((item, index) => (
             <ListItem key={index} disablePadding className={classes.listItem}>
               <ListItemButton
-                className={classes.listItemButton}
+                className={`${classes.listItemButton} zoom`}
                 onClick={() => handleSelectedField(item.type, item.id)}
                 selected={selectedFieldsId === item.id}
               >

--- a/ui/src/pages/FormsCreateOrEdit/TabPropertiesPreview/FieldProperties.jsx
+++ b/ui/src/pages/FormsCreateOrEdit/TabPropertiesPreview/FieldProperties.jsx
@@ -407,6 +407,8 @@ const FieldProperties = () => {
                   ))}
                 </Stack>
               )}
+              className='neutralize-zoom-select'
+              MenuProps={{ className: 'neutralize-zoom-select-menu' }}
             >
               {formatFiles.map((format) => (
                 <MenuItem key={format} value={format}>

--- a/ui/src/pages/FormsCreateOrEdit/TabPropertiesPreview/MobilePreview.jsx
+++ b/ui/src/pages/FormsCreateOrEdit/TabPropertiesPreview/MobilePreview.jsx
@@ -91,7 +91,12 @@ const MobilePreview = (props) => {
         {item.type === 'dropdown' && (
           <FormControl variant='filled' fullWidth className={classes.formControlMobile}>
             <InputLabel>Answer</InputLabel>
-            <Select label={item.label} size='small' className='heightFitContent'>
+            <Select
+              label={item.label}
+              size='small'
+              className='neutralize-zoom-select heightFitContent'
+              MenuProps={{ className: 'neutralize-zoom-select-menu' }}
+            >
               {item.optionList.map((item, index) => (
                 <MenuItem key={index} value={item.label}>
                   <Typography variant='caption' className='displayBlock' noWrap>{item.label || `Option #${index + 1}`}</Typography>

--- a/ui/src/pages/SignUp/SignUp.jsx
+++ b/ui/src/pages/SignUp/SignUp.jsx
@@ -147,24 +147,27 @@ const SignUp = () => {
       </FormControl>
 
       {/* COUNTRY AUTOCOMPLETE */}
-      <Autocomplete
-        value={formObject.country}
-        onChange={(event, newValue) => handleFormObjectChange('country', newValue)}
-        inputValue={countryInputValue}
-        onInputChange={(event, newInputValue) => setCountryInputValue(newInputValue)}
-        options={countries}
-        getOptionLabel={(option) => option.name}
-        fullWidth
-        renderInput={(params) => (
-          <TextField 
-            {...params} 
-            label='Country'
-            color='secondary'
-            error={formHelperObject.country}
-            helperText={formHelperObject.country ?? ' '}
-          />
-        )}
-      />
+      <FormControl className='no-zoom' fullWidth>
+        <Autocomplete
+          value={formObject.country}
+          onChange={(event, newValue) => handleFormObjectChange('country', newValue)}
+          inputValue={countryInputValue}
+          onInputChange={(event, newInputValue) => setCountryInputValue(newInputValue)}
+          options={countries}
+          getOptionLabel={(option) => option.name}
+          fullWidth
+          renderInput={(params) => (
+            <TextField 
+              {...params} 
+              label='Country'
+              color='secondary'
+              error={formHelperObject.country}
+              helperText={formHelperObject.country ?? ' '}
+            />
+          )}
+          className='neutralize-zoom-autocomplete'
+        />
+      </FormControl>
 
       {/* PHONE NUMBER FORM */}
       <FormControl 


### PR DESCRIPTION
### **Before**
<img width="1440" alt="Screen Shot 2022-09-26 at 13 54 53" src="https://user-images.githubusercontent.com/22076215/192203387-b4890ad9-9c0f-43f9-9b2f-c07c5a2e3dca.png">

### **After**
<img width="1440" alt="Screen Shot 2022-09-26 at 13 54 21" src="https://user-images.githubusercontent.com/22076215/192203409-fdb4925f-496f-4321-9470-3ee77b35448c.png">

### **General Changes**
1. fix zoom effect on several page
2. add link

### **Detail Changes**
1. create reuseable `class neutralize zoom effect` for select, sortable js, menu & autocomplete
2. fix `typo classname`
3. fix `sortable drag & drop` zoom effect
4. fix `create signature` zoom effect
5. add `link` to `footer logo`
6. fix zoom effect on page `create form`, `sign up` & `form fill`