### PR TITLE
Features/page forgot password api

### DIFF
--- a/ui/src/pages/ForgotPassword/ForgotPassword.jsx
+++ b/ui/src/pages/ForgotPassword/ForgotPassword.jsx
@@ -5,12 +5,14 @@ import { useNavigate } from 'react-router-dom'
 import { AllPagesContext } from 'contexts/AllPagesContext'
 
 // MUIS
-import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
 import FormHelperText from '@mui/material/FormHelperText'
 import InputLabel from '@mui/material/InputLabel'
 import OutlinedInput from '@mui/material/OutlinedInput'
 import Typography from '@mui/material/Typography'
+
+// MUI LABS
+import LoadingButton from '@mui/lab/LoadingButton'
 
 // SERVICES
 import { postForgotPasswordUser } from 'services/users'
@@ -41,7 +43,7 @@ const ForgotPassword = () => {
 
   const [ formObject, setFormObject ] = useState(initialFormObject)
   const [ formHelperObject, setFormHelperObject ] = useState(initialFormHelperObject)
-  const [ isActionButtonDisabled, setIsActionButtonDisabled ] = useState(false)
+  const [ isLoading, setIsLoading ] = useState(false)
 
   // HANDLE FORM INPUT CHANGE
   const handleFormObjectChange = (inputKey, inputNewValue) => {
@@ -56,6 +58,7 @@ const ForgotPassword = () => {
   // HANDLE BUTTON CLICK
   const handleFormButtonClick = async (inputEvent) => {
     inputEvent.preventDefault()
+    setIsLoading(true)
 
     // CHECK IF USER INPUTS ARE EMPTY
     if (doesObjectContainDesiredValue(formObject, '')) {
@@ -101,6 +104,8 @@ const ForgotPassword = () => {
 
       abortController.abort()
     }
+
+    setIsLoading(false)
   }
 
   return (
@@ -141,16 +146,17 @@ const ForgotPassword = () => {
       </FormControl>
 
       {/* RESET MY PASSWORD BUTTON */}
-      <Button
+      <LoadingButton
         variant='contained'
         fullWidth
         className={layoutClasses.buttonAction}
-        disabled={isActionButtonDisabled}
+        disabled={doesObjectContainDesiredValue(formObject, '')}
+        loading={isLoading}
         disableElevation
         type='submit'
       >
         Reset My Password
-      </Button>
+      </LoadingButton>
     </form>
   )
 }

--- a/ui/src/pages/ForgotPassword/ForgotPassword.jsx
+++ b/ui/src/pages/ForgotPassword/ForgotPassword.jsx
@@ -1,19 +1,35 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+// CONTEXTS
+import { AllPagesContext } from 'contexts/AllPagesContext'
 
 // MUIS
 import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
 import FormHelperText from '@mui/material/FormHelperText'
 import InputLabel from '@mui/material/InputLabel'
-import Link from '@mui/material/Link'
 import OutlinedInput from '@mui/material/OutlinedInput'
 import Typography from '@mui/material/Typography'
+
+// SERVICES
+import { postForgotPasswordUser } from 'services/users'
 
 // STYLES
 import useLayoutStyles from 'styles/layoutAuthentication'
 
+// UTILITIES
+import { 
+  didSuccessfullyCallTheApi,
+  doesObjectContainDesiredValue, 
+} from 'utilities/validation'
+
 const ForgotPassword = () => {
   const layoutClasses = useLayoutStyles()
+
+  const { setSnackbarObject } = useContext(AllPagesContext)
+
+  const navigate = useNavigate()
   
   const initialFormObject = {
     email: '',
@@ -38,8 +54,53 @@ const ForgotPassword = () => {
   }
 
   // HANDLE BUTTON CLICK
-  const handleFormButtonClick = (inputEvent) => {
+  const handleFormButtonClick = async (inputEvent) => {
     inputEvent.preventDefault()
+
+    // CHECK IF USER INPUTS ARE EMPTY
+    if (doesObjectContainDesiredValue(formObject, '')) {
+      setSnackbarObject({
+        open: true,
+        severity: 'error',
+        title: '',
+        message: 'Please fill all fields',
+      })
+    }
+    // USER INPUTS ARE NOT EMPTY
+    else {
+      const abortController = new AbortController()
+  
+      const resultForgotPasswordUser = await postForgotPasswordUser(
+        abortController.signal,
+        { email: formObject?.email }
+      )
+
+      // REDIRECT THE USER IF SUCCESSFULLY CALLING THE API
+      if (didSuccessfullyCallTheApi(resultForgotPasswordUser.status)) {
+        setSnackbarObject({
+          open: true,
+          severity: 'success',
+          title: '',
+          message: 'Successfully sending request to your email',
+        })
+
+        navigate(`/authentication-finish?type=forgot-password&email=${formObject.email}`)
+      }
+      // SHOW AN ERROR MESSAGE IF UNSUCCESSFULLY CALLING THE API
+      else {
+        // UNREGISTERED EMAIL
+        if (resultForgotPasswordUser.status === 400) {
+          setSnackbarObject({
+            open: true,
+            severity: 'error',
+            title: '',
+            message: 'Unregistered email',
+          })
+        }
+      }
+
+      abortController.abort()
+    }
   }
 
   return (

--- a/ui/src/services/users.js
+++ b/ui/src/services/users.js
@@ -1,13 +1,13 @@
 //APIS
 import axios from 'apis/axios'
 
-export const postRegisterUser = async (
+export const postForgotPasswordUser = async (
   inputSignal, 
   inputBodyParams, 
 ) => {
   try {
     const response = await axios.post(
-      '/api/users/register', 
+      '/api/users/reset-password', 
       inputBodyParams, 
       {
         signal: inputSignal,
@@ -28,6 +28,26 @@ export const postLoginUser = async (
   try {
     const response = await axios.post(
       '/api/users/login', 
+      inputBodyParams, 
+      {
+        signal: inputSignal,
+      },
+    )
+
+    return response
+  } catch (error) {
+    if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}
+
+export const postRegisterUser = async (
+  inputSignal, 
+  inputBodyParams, 
+) => {
+  try {
+    const response = await axios.post(
+      '/api/users/register', 
       inputBodyParams, 
       {
         signal: inputSignal,


### PR DESCRIPTION
### Before
Forgot Password page
![image](https://user-images.githubusercontent.com/24468466/193558280-cc6a9db8-e15e-4496-9fd8-6008530d1762.png)

### After
Forgot Password page
![image](https://user-images.githubusercontent.com/24468466/193558056-6d4d30b0-652d-4b96-84c4-0d622bab13fa.png)

### General Changes
1. implement forgot password user API on the Forgot Password page

### Detail Changes
1. add `postForgotPasswordUser` function on the `users` service
2. implement forgot password user API (`postForgotPasswordUser` function) on the Forgot Password page