### PR TITLE
Features/page reset password api

### DIFF
--- a/ui/src/pages/ResetPassword/ResetPassword.jsx
+++ b/ui/src/pages/ResetPassword/ResetPassword.jsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom'
 import { AllPagesContext } from 'contexts/AllPagesContext'
 
 // MUIS
-import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
 import FormHelperText from '@mui/material/FormHelperText'
 import IconButton from '@mui/material/IconButton'
@@ -18,6 +17,9 @@ import Typography from '@mui/material/Typography'
 // MUI ICONS
 import IconVisibility from '@mui/icons-material/Visibility'
 import IconVisibilityOff from '@mui/icons-material/VisibilityOff'
+
+// MUI LABS
+import LoadingButton from '@mui/lab/LoadingButton'
 
 // SERVICES
 import { postResetPasswordUser } from 'services/users'
@@ -54,7 +56,7 @@ const ResetPassword = () => {
   const [ formHelperObject, setFormHelperObject ] = useState(initialFormHelperObject)
   const [ isNewPasswordShown, setIsNewPasswordShown ] = useState(false)
   const [ isConfirmPasswordShown, setIsConfirmPasswordShown ] = useState(false)
-  const [ isActionButtonDisabled, setIsActionButtonDisabled ] = useState(false)
+  const [ isLoading, setIsLoading ] = useState(false)
 
   // HANDLE FORM INPUT CHANGE
   const handleFormObjectChange = (inputKey, inputNewValue) => {
@@ -69,6 +71,7 @@ const ResetPassword = () => {
   // HANDLE BUTTON CLICK
   const handleFormButtonClick = async (inputEvent) => {
     inputEvent.preventDefault()
+    setIsLoading(true)
 
     // CHECK IF USER INPUTS ARE EMPTY
     if (doesObjectContainDesiredValue(formObject, '')) {
@@ -124,6 +127,8 @@ const ResetPassword = () => {
 
       abortController.abort()
     }
+
+    setIsLoading(false)
   }
 
   return (
@@ -200,16 +205,17 @@ const ResetPassword = () => {
       </FormControl>
 
       {/* RESET MY PASSWORD BUTTON */}
-      <Button
+      <LoadingButton
         variant='contained'
         fullWidth
         className={layoutClasses.buttonAction}
-        disabled={isActionButtonDisabled}
+        disabled={doesObjectContainDesiredValue(formObject, '')}
+        loading={isLoading}
         disableElevation
         type='submit'
       >
         Save New Password
-      </Button>
+      </LoadingButton>
     </form>
   )
 }

--- a/ui/src/pages/SignUp/SignUp.jsx
+++ b/ui/src/pages/SignUp/SignUp.jsx
@@ -101,7 +101,7 @@ const SignUp = () => {
       const resultRegisterUser = await postRegisterUser(
         abortController.signal,
         {
-          username: formObject?.fullName,
+          fullname: formObject?.fullName,
           password: formObject?.password,
           email: formObject?.email,
           phoneNo: formObject?.phoneNumber,

--- a/ui/src/services/users.js
+++ b/ui/src/services/users.js
@@ -60,3 +60,23 @@ export const postRegisterUser = async (
     else return error.response
   }
 }
+
+export const postResetPasswordUser = async (
+  inputSignal, 
+  inputBodyParams, 
+) => {
+  try {
+    const response = await axios.post(
+      '/api/users/reset-password/verify', 
+      inputBodyParams, 
+      {
+        signal: inputSignal,
+      },
+    )
+
+    return response
+  } catch (error) {
+    if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}


### PR DESCRIPTION
### Before
Reset Password page
![image](https://user-images.githubusercontent.com/24468466/193753726-31d2b3e8-42d6-41cf-966d-729edb3a0660.png)

### After
Reset Password page
![image](https://user-images.githubusercontent.com/24468466/193753046-d7f938cc-71a2-46fa-b440-5d9aaed3fe41.png)

### General Changes
1. implement reset password user API on the Reset Password page

### Detail Changes
1. add `postResetPasswordUser` function on the `users` service
2. implement reset password user API (`postResetPasswordUser` function) on the Reset Password page