### PR TITLE
Frontend features/implement api form delete

### DIFF
--- a/ui/src/components/DataGridRenderCell/CellGroups.jsx
+++ b/ui/src/components/DataGridRenderCell/CellGroups.jsx
@@ -9,32 +9,42 @@ import Typography from '@mui/material/Typography'
 import useLayoutStyles from 'styles/layoutPrivate'
 
 const CellGroups = (props) => {
-  const { dataValue } = props
+  const { dataValue, limitShowGroup } = props
 
   const layoutClasses = useLayoutStyles()
 
   return (
     <Stack direction='row' alignItems={'center'}>
-      <Typography variant='inherit'>
-        {dataValue[0]}{dataValue.length > 1 ? `, ${dataValue[1]}` : 'Default'}&nbsp;
-      </Typography>
-      {
-        dataValue.length > 2 && (
-          <Avatar className={layoutClasses.avatar} variant='square'>
-            +{dataValue.length - 2}
-          </Avatar>
-        )
-      }
+      {limitShowGroup
+        ? (<>
+          <Typography variant='inherit'>
+            {dataValue[0]?.name || 'Default'}
+            {dataValue.length >= 2 && `, ${dataValue[1]?.name}`}&nbsp;
+          </Typography>
+          {(limitShowGroup && dataValue.length > 2) && (
+            <Avatar className={layoutClasses.avatar} variant='square'>
+              +{dataValue.length - 2}
+            </Avatar>
+          )}
+        </>)
+        : (<>
+          {dataValue.length >= 1
+            ? dataValue.map(item => item.name).toString().replace(/\,/g, ', ')
+            : 'Default'
+          }
+        </>)}
     </Stack>
   )
 }
 
 CellGroups.defaultProps = {
   dataValue: [],
+  limitShowGroup: true,
 }
 
 CellGroups.propTypes = {
   dataValue: PropTypes.array.isRequired,
+  limitShowGroup: PropTypes.bool,
 }
 
 export default CellGroups

--- a/ui/src/pages/Forms/Forms.jsx
+++ b/ui/src/pages/Forms/Forms.jsx
@@ -27,7 +27,7 @@ import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 
 // SERVICES
-import { postCreateFormTemplate, postGetListFormTemplate } from 'services/formTemplate'
+import { deleteFormTemplate, postCreateFormTemplate, postGetListFormTemplate } from 'services/formTemplate'
 
 // STYLES
 import useLayoutStyles from 'styles/layoutPrivate'
@@ -220,13 +220,48 @@ const Forms = () => {
     isDataGridLoading && setIsDataGridLoading(false)
   }
 
+  // HANLDE DELETE FORM TEMPLATE
+  const handleDeleteFormTemplate = async () => {
+    setIsDataGridLoading(true)
+    const abortController = new AbortController()
+
+    setDialogDeleteForms({})
+    setIsFlyoutShown(false)
+
+    if(selectionModel.length >= 1) {
+      // CURRENTLY JUST CAN DELETE 1 ITEM
+      const response = await deleteFormTemplate(selectionModel[0], abortController.signal, auth.accessToken)
+
+      if(didSuccessfullyCallTheApi(response?.status)) {
+        fetchingFormsList(abortController.signal, true)
+        setSnackbarObject({
+          open: true,
+          severity:'success',
+          title:'',
+          message:'Form deleted successfully'
+        })
+        setSelectionModel([])
+      } else {
+        setSnackbarObject({
+          open: true,
+          severity:'error',
+          title:'',
+          message:'Something gone wrong'
+        })
+      }
+    }
+
+    setIsDataGridLoading(false)
+    abortController.abort()
+  }
+
   useEffect(() => {
     if (selectionModel.length === 1) {
       setIsFlyoutShown(true)
+    } else {
+      setIsFlyoutShown(false)
     }
   }, [selectionModel])
-
-  // SIDE EFFECT FETCHING FIRSTTIME MOUNT
 
   // SIDE EFFECT FILTERS
   useEffect(() => {
@@ -329,15 +364,7 @@ const Forms = () => {
         setDialogConfirmationObject={setDialogDeleteForms}
         cancelButtonText='Cancel'
         continueButtonText='Delete'
-        onContinueButtonClick={() => {
-          setDialogDeleteForms({})
-          setSnackbarObject({
-            open: true,
-            severity:'success',
-            title:'',
-            message:'Form deleted successfully'
-          })
-        }}
+        onContinueButtonClick={() => handleDeleteFormTemplate()}
         onCancelButtonClick={() => setDialogDeleteForms({})}
       />
 

--- a/ui/src/pages/Forms/FormsFlyout/MainMenu.jsx
+++ b/ui/src/pages/Forms/FormsFlyout/MainMenu.jsx
@@ -1,10 +1,12 @@
 import { useContext, useState } from 'react'
 
+// COMPONENTS
+import CellGroups from 'components/DataGridRenderCell/CellGroups'
+
 // CONTEXTS
 import { PrivateLayoutContext } from 'contexts/PrivateLayoutContext'
 
 // MUIS
-import Avatar from '@mui/material/Avatar'
 import Button from '@mui/material/Button'
 import Collapse from '@mui/material/Collapse'
 import IconButton from '@mui/material/IconButton'
@@ -146,17 +148,8 @@ const MainMenu = (props) => {
                 }
                 secondary={
                   item.title === 'Groups' 
-                    ? <Stack direction={'row'} alignItems='center'>
-                      <Typography variant='body2' className='colorTextPrimary'>
-                        {item.value.length ? item.value[0] : 'Default'}&nbsp;
-                      </Typography>
-                      {
-                        item.value.length > 1 && (
-                          <Avatar className={layoutClasses.avatar} variant='square'>
-                            +{item.value.length - 1}
-                          </Avatar>
-                        )
-                      }
+                    ? <Stack className='colorTextPrimary'>
+                      <CellGroups dataValue={item.value} limitShowGroup={false} />
                     </Stack>
                     : (<Typography variant='body2'>
                       {item.value}

--- a/ui/src/services/formTemplate.js
+++ b/ui/src/services/formTemplate.js
@@ -58,3 +58,16 @@ export const postGetListFormTemplate = async (inputSignal, inputQuery, inputPara
     else return error.response
   }
 }
+
+export const deleteFormTemplate = async (formTemplateId, inputSignal, inputToken) => {
+  try {
+    const response = await axiosPrivate.delete(`/form/template/${formTemplateId}`, {
+      signal: inputSignal,
+      headers: { 'Authorization': `Bearer ${inputToken}` }
+    })
+    return response
+  } catch (error) {
+    if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}


### PR DESCRIPTION
### **Before**
<img width="1440" alt="Screen Shot 2022-10-11 at 16 01 31" src="https://user-images.githubusercontent.com/22076215/195038528-07eb8cf7-90be-4443-b622-f28621b5bdf5.png">

### **After**
<img width="1440" alt="Screen Shot 2022-10-11 at 16 02 00" src="https://user-images.githubusercontent.com/22076215/195038518-8eb9b715-009d-4bf7-9c98-308aa7e1bd09.png">

### **General Changes**
1. implement api form template delete
2. fix group on form page

### **Detail Changes**
1. implement `api form template delete` on `form page`
2. fix table cell `group` on `form page`
3. fix flyout detail `group` on `form page`
4. recustom `GroupCell` and make it `reuseable` on `flyout detail form page`