### PR TITLE
Frontend features/react lazy implementation

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext } from 'react'
+import { Suspense, useEffect, useContext } from 'react'
 import { Routes, Route } from 'react-router-dom'
 
 // ASSETS
@@ -51,7 +51,7 @@ const App = () => {
   }, [])
 
   return (
-    <>
+    <Suspense fallback={<div/>}>
       <Routes>
         {routes.map((item, index) => (
           <Route 
@@ -70,7 +70,7 @@ const App = () => {
         title={snackbarObject.title}
         message={snackbarObject.message}
       />
-    </>
+    </Suspense>
   )
 }
 

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -1,23 +1,25 @@
+import { lazy } from 'react'
+
 // CONTEXTS
 import { PageFormsCreateOrEditContextProvider } from 'contexts/PageFormsCreateOrEditContext'
 import { PrivateLayoutContextProvider } from 'contexts/PrivateLayoutContext'
 
 // PAGES
-import AuthenticationFinish from 'pages/AuthenticationFinish/AuthenticationFinish'
-import Devices from 'pages/Devices/Devices'
-import Error from 'pages/Error'
-import FillForm from 'pages/FillForm/FillForm'
-import FillFormFinish from 'pages/FillFormFinish/FillFormFinish'
-import ForgotPassword from 'pages/ForgotPassword/ForgotPassword'
-import Forms from 'pages/Forms/Forms'
-import FormsCreateOrEdit from 'pages/FormsCreateOrEdit/FormsCreateOrEdit'
-import FormsSubmissions from 'pages/FormsSubmissions/FormsSubmissions'
-import FormsView from 'pages/FormsView/FormsView'
-import Groups from 'pages/Groups/Groups'
-import Home from 'pages/Home/Home'
-import ResetPassword from 'pages/ResetPassword/ResetPassword'
-import SignIn from 'pages/SignIn/SignIn'
-import SignUp from 'pages/SignUp/SignUp'
+const AuthenticationFinish = lazy(() => import('pages/AuthenticationFinish/AuthenticationFinish'))
+const Devices = lazy(() => import('pages/Devices/Devices'))
+const Error = lazy(() => import('pages/Error'))
+const FillForm = lazy(() => import('pages/FillForm/FillForm'))
+const FillFormFinish = lazy(() => import('pages/FillFormFinish/FillFormFinish'))
+const ForgotPassword = lazy(() => import('pages/ForgotPassword/ForgotPassword'))
+const Forms = lazy(() => import('pages/Forms/Forms'))
+const FormsCreateOrEdit = lazy(() => import('pages/FormsCreateOrEdit/FormsCreateOrEdit'))
+const FormsSubmissions = lazy(() => import('pages/FormsSubmissions/FormsSubmissions'))
+const FormsView = lazy(() => import('pages/FormsView/FormsView'))
+const Groups = lazy(() => import('pages/Groups/Groups'))
+const Home = lazy(() => import('pages/Home/Home'))
+const ResetPassword = lazy(() => import('pages/ResetPassword/ResetPassword'))
+const SignIn = lazy(() => import('pages/SignIn/SignIn'))
+const SignUp = lazy(() => import('pages/SignUp/SignUp'))
 
 const routes = [
   // AUTHENTICATION


### PR DESCRIPTION
### Before
The Sign-In Page (The app bundle size was 1.8 Mb)
![image](https://user-images.githubusercontent.com/24468466/199906867-c2558942-5cf3-4c4e-9465-3421cae7c658.png)

### After
The Sign-In Page (The app bundle size was 700 kb)
![image](https://user-images.githubusercontent.com/24468466/199906936-e05d54b0-91c5-4c64-b7bc-4d37a6fa7ada.png)

### General Changes
1. implement the lazy load to reduce the app bundle size

### Detail Changes
1. change default imports with lazy imports on the `routes` file
2. wrap the components with the `Suspense` component on the root App component