### PR TITLE
frontend revisions/fix camera preview that looks enlarged

### DIFF
--- a/ui/src/pages/FillForm/DialogCamera/DialogCamera.jsx
+++ b/ui/src/pages/FillForm/DialogCamera/DialogCamera.jsx
@@ -153,7 +153,7 @@ const DialogCamera = (props) => {
             <Webcam
               ref={webcamRef}
               audio={false}
-              className={classes.webcam}
+              className={classes.webcamDesktop}
               width='100%'
               screenshotFormat='image/jpeg'
               mirrored={cameraPosition === 'user' ? true : false}
@@ -164,7 +164,7 @@ const DialogCamera = (props) => {
           {/* RESULT PHOTO */}
           {resultPhoto && (
             <Box
-              className={classes.resultPhoto}
+              className={detectDeviceType() ? classes.resultPhotoDesktop : classes.resultPhotoMobile}
               component='img'
               src={resultPhoto}
             />

--- a/ui/src/pages/FillForm/DialogCamera/dialogCameraUseStyles.js
+++ b/ui/src/pages/FillForm/DialogCamera/dialogCameraUseStyles.js
@@ -47,12 +47,18 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     backgroundColor: theme.palette.additional.drawer.background,
   },
-  webcam: {
+  webcamDesktop: {
     height: '100%',
-    objectFit: 'cover',
   },
-  resultPhoto: {
-    height: '438px',
+  resultPhotoDesktop: {
+    height: '100%'
+  },
+  resultPhotoMobile: {
+    maxWidth: '100%',
+    // result for tablet
+    [theme.breakpoints.up('sm')]: {
+      maxWidth: '75%',
+    }
   },
   buttonTakePhoto: {
     backgroundColor: theme.palette.error.main,


### PR DESCRIPTION
### **Before**
preview and result camera are overlflow from element and look like zoomed

### **After**
make preview and result camera not full screen

### **General Changes**
- fix dialog camera

### **Detail Changes**
- [x] fix camera preview that looks enlarged