### PR TITLE
frontend features/resend confirmation email

### DIFF
--- a/ui/src/layouts/Authentication/AppBarText.jsx
+++ b/ui/src/layouts/Authentication/AppBarText.jsx
@@ -1,14 +1,59 @@
+import { useContext } from 'react'
 import { useLocation, useSearchParams } from 'react-router-dom'
+
+// CONTEXTS
+import { AllPagesContext } from 'contexts/AllPagesContext'
 
 // MUIS
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
 
+// SERVICES
+import { postResendEmailConfirmation } from 'services/users'
+
+// UTILITIES
+import { didSuccessfullyCallTheApi } from 'utilities/validation'
+
 const AppBarText = () => {
   const location = useLocation()
   const [ searchParams ] = useSearchParams()
 
+  // CONTEXTS
+  const { setSnackbarObject } = useContext(AllPagesContext)
+
   const pageType = searchParams.get('type')
+  const email = searchParams.get('email')
+
+  // HANDLE RESEND CLICK
+  const handleResendClick = async (event, type) => {
+    event.preventDefault()
+    const abortController = new AbortController()
+
+    if(type === 'sign-up' && email) {
+      const response = await postResendEmailConfirmation(
+        abortController.signal,
+        {
+          email,
+        }
+      )
+
+      if(didSuccessfullyCallTheApi(response?.status)) {
+        setSnackbarObject({
+          open: true,
+          severity:'success',
+          title: '',
+          message: 'Successfully requested to resend confirmation email',
+        })
+      } else {
+        setSnackbarObject({
+          open: true,
+          severity:'error',
+          title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
+          message: response?.data?.error?.message || 'Something gone wrong',
+        })
+      }
+    }
+  }
 
   if (
     location.pathname === '/sign-up' ||
@@ -63,6 +108,7 @@ const AppBarText = () => {
         href='#'
         underline='none'
         className='fontFamilySpaceMono fontWeight700'
+        onClick={(event) => handleResendClick(event, pageType)}
       >
         Resend
       </Link>

--- a/ui/src/layouts/Authentication/AppBarText.jsx
+++ b/ui/src/layouts/Authentication/AppBarText.jsx
@@ -42,17 +42,19 @@ const AppBarText = () => {
           open: true,
           severity:'success',
           title: '',
-          message: 'Successfully requested to resend confirmation email',
+          message: 'Successfully requested to resend the confirmation email',
         })
       } else {
         setSnackbarObject({
           open: true,
           severity:'error',
           title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-          message: response?.data?.error?.message || 'Something gone wrong',
+          message: response?.data?.error?.message || 'Something went wrong',
         })
       }
     }
+
+    abortController.abort()
   }
 
   if (

--- a/ui/src/services/users.js
+++ b/ui/src/services/users.js
@@ -110,3 +110,17 @@ export const postResetPasswordUser = async (
     else return error.response
   }
 }
+
+export const postResendEmailConfirmation = async (inputSignal, inputBodyParams) => {
+  try {
+    const response = await axios.post('/api/users/email-verify', inputBodyParams, {
+      signal: inputSignal,
+    })
+
+    return response
+  } catch (error) {
+    if (error.message === 'canceled') return { status: 'Canceled' }
+    else if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}


### PR DESCRIPTION
### **Before**
not yet api implement resend confirmation email

### **After**
<img width="1440" alt="Screen Shot 2022-11-09 at 13 31 01" src="https://user-images.githubusercontent.com/22076215/200747915-e7ea7a1b-287e-4d48-a4c8-52f555791dec.png">

### **General Changes**
- implement resend confirmation email

### **Detail Changes**
- [x] implement api resend confirmation email