### PR TITLE
Frontend contds/page sumbissions api

### DIFF
--- a/ui/src/pages/Forms/Forms.jsx
+++ b/ui/src/pages/Forms/Forms.jsx
@@ -367,7 +367,7 @@ const Forms = () => {
             selectionModel={selectionModel} 
             setSelectionModel={setSelectionModel}
             // ACTIONS
-            onRowDoubleClick={(params, event, details) => navigate(`/forms/${params.row.id}/submissions`)}
+            onRowDoubleClick={(params, event, details) => navigate(`/forms/submissions/${params.row.id}`)}
           />
         </LoadingPaper>
 

--- a/ui/src/pages/Forms/FormsFlyout/Submissions.jsx
+++ b/ui/src/pages/Forms/FormsFlyout/Submissions.jsx
@@ -44,7 +44,7 @@ const Submissions = (props) => {
 
   // GET SUBMISSIONS VIEW ALL URL
   const getSubmissionsViewAllUrl = () => {
-    if(rows.length === 1) return `/forms/${rows[0].id}/submissions`
+    if(rows.length === 1) return `/forms/submissions/${rows[0].id}`
     else return '#'
   }
 

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -89,6 +89,8 @@ const FormsSubmissions = () => {
   // CONTENT
   const [ formTemplateDetail, setFormTemplateDetail ] = useState(null)
   const [ isDataGridLoading, setIsDataGridLoading ] = useState(false)
+  const [ areDynamicColumnTitlesAdded, setAreDynamicColumnTitlesAdded ] = useState(false)
+  const [ areDynamicColumnsValuesAdded, setAreDynamicColumnsValuesAdded ] = useState(false)
   // DATA GRID - BASE
   const [ columnList, setColumnList ] = useState(initialColumns)
   const [ tableData, setTableData ] = useState([])
@@ -165,6 +167,7 @@ const FormsSubmissions = () => {
           source: submissionItem?.source ?? '-',
           submissionDate: submissionItem?.submit_date ?? '-',
           submissionAddress: submissionItem.submit_location?.address ?? '-',
+          values: submissionItem.values,
         }
       })
 
@@ -179,6 +182,7 @@ const FormsSubmissions = () => {
     if (formTemplateDetail && formTemplateDetail?.fields?.length > 0) {
       const newColumnList = [ ...columnList, ...formTemplateDetail?.fields?.map(item => {
         return {
+          // DATA GRID OBJECTS
           field: item.id,
           headerName: item.label,
           flex: 1,
@@ -187,10 +191,39 @@ const FormsSubmissions = () => {
           areFilterAndSortShown: false,
           headerClassName: 'cell-source-custom',
           cellClassName: 'cell-source-custom',
+          // DYNAMIC FIELD OBJECTS
+          fieldType: item.type,
         }
       })]
 
       setColumnList(newColumnList)
+      setAreDynamicColumnTitlesAdded(true)
+    }
+  }
+
+  const updateTableDataDynamically = () => {
+    // NOTE: DYNAMIC COLUMNS START FROM THE 3RD INDEX
+    if (
+      columnList.length > 3 && tableData.length > 0 && 
+      areDynamicColumnTitlesAdded && !areDynamicColumnsValuesAdded
+    ) {
+      const dynamicColumnList = columnList.filter((item, index) => index >= 3)
+
+      const newTableData = tableData.map((tableRow, tableIndex) => {
+        console.log(tableRow)
+        return {
+          ...tableRow,
+          ...dynamicColumnList.reduce((result, columnItem, columnIndex) => {
+            // TO DO: ADD FUNCTION TO GET THE VALUE
+            return { [columnItem.field]: tableRow?.values?.[columnItem.field]?.file_ids }
+          })
+        }
+      })
+
+      console.log(newTableData)
+
+      setAreDynamicColumnsValuesAdded(true)
+      setTableData(newTableData)
     }
   }
   
@@ -221,6 +254,12 @@ const FormsSubmissions = () => {
   useEffect(() => {
     updateColumnsDynamically()
   }, [formTemplateDetail])
+
+  useEffect(() => {
+    updateTableDataDynamically()
+  }, [columnList, tableData, areDynamicColumnTitlesAdded])
+
+  // console.log(tableData)
 
   return (
     <>

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -179,6 +179,15 @@ const FormsSubmissions = () => {
     setIsDataGridLoading(false)
   }
 
+  const getValueByColumnType = (inputParams) => {
+    if (inputParams?.value?.type === 'text' || inputParams?.value?.type === 'date' || inputParams?.value?.type === 'rating') return inputParams?.value?.value
+    else if (inputParams?.value?.type === 'radio_group' || inputParams?.value?.type === 'dropdown') {
+      const optionList = formTemplateDetail?.fields?.find(item => item.id === inputParams?.field)?.options
+      const selectedOption = optionList.find((item, index) => index === inputParams?.value?.value_index)
+      return selectedOption.label
+    }
+  }
+
   const updateColumnsDynamically = () => {
     if (
       formTemplateDetail && formTemplateDetail?.fields?.length > 0 &&
@@ -194,6 +203,7 @@ const FormsSubmissions = () => {
           areFilterAndSortShown: false,
           headerClassName: 'cell-source-custom',
           cellClassName: 'cell-source-custom',
+          valueGetter: (params) => getValueByColumnType(params),
         }
       })]
 

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -179,10 +179,12 @@ const FormsSubmissions = () => {
   }
 
   const updateColumnsDynamically = () => {
-    if (formTemplateDetail && formTemplateDetail?.fields?.length > 0) {
+    if (
+      formTemplateDetail && formTemplateDetail?.fields?.length > 0 &&
+      !areDynamicColumnTitlesAdded
+    ) {
       const newColumnList = [ ...columnList, ...formTemplateDetail?.fields?.map(item => {
         return {
-          // DATA GRID OBJECTS
           field: item.id,
           headerName: item.label,
           flex: 1,
@@ -191,8 +193,6 @@ const FormsSubmissions = () => {
           areFilterAndSortShown: false,
           headerClassName: 'cell-source-custom',
           cellClassName: 'cell-source-custom',
-          // DYNAMIC FIELD OBJECTS
-          fieldType: item.type,
         }
       })]
 
@@ -207,20 +207,19 @@ const FormsSubmissions = () => {
       columnList.length > 3 && tableData.length > 0 && 
       areDynamicColumnTitlesAdded && !areDynamicColumnsValuesAdded
     ) {
-      const dynamicColumnList = columnList.filter((item, index) => index >= 3)
+      const dynamicColumnList = columnList.filter((item, index) => index > 2)
 
-      const newTableData = tableData.map((tableRow, tableIndex) => {
-        console.log(tableRow)
+      const newTableData = tableData.map((tableRowItem) => {
+        const columnWithValueObject = dynamicColumnList.reduce((result, columnItem) => {
+          result[columnItem.field] = tableRowItem?.values?.[columnItem.field]
+          return result
+        }, {})
+
         return {
-          ...tableRow,
-          ...dynamicColumnList.reduce((result, columnItem, columnIndex) => {
-            // TO DO: ADD FUNCTION TO GET THE VALUE
-            return { [columnItem.field]: tableRow?.values?.[columnItem.field]?.file_ids }
-          })
+          ...tableRowItem,
+          ...columnWithValueObject,
         }
       })
-
-      console.log(newTableData)
 
       setAreDynamicColumnsValuesAdded(true)
       setTableData(newTableData)
@@ -258,8 +257,6 @@ const FormsSubmissions = () => {
   useEffect(() => {
     updateTableDataDynamically()
   }, [columnList, tableData, areDynamicColumnTitlesAdded])
-
-  // console.log(tableData)
 
   return (
     <>

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -368,7 +368,7 @@ const FormsSubmissions = () => {
             // CLASSES
             className={classes.tableFormsSubmissions}
             // CELL
-            onCellClick={(event, params, details) => navigate(`/forms/${event.row.id}/view`)}
+            onRowDoubleClick={(params, event, details) => navigate(`/forms/submission-detail?formTemplateId=${formTemplateId}&submissionId=${params.row.id}`)}
           />
         </LoadingPaper>
       </Stack>

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -60,6 +60,7 @@ const FormsSubmissions = () => {
       width: 140,
       hide: false,
       areFilterAndSortShown: true,
+      valueGetter: (params) => params.row.source.label,
     },
     {
       field: 'submissionDate',

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -69,7 +69,7 @@ const routes = [
     routeType: 'private',
   },
   {
-    path: '/forms/:formTemplateId/submissions',
+    path: '/forms/submissions/:formTemplateId',
     element: <FormsSubmissions/>,
     routeType: 'private',
   },

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -69,7 +69,7 @@ const routes = [
     routeType: 'private',
   },
   {
-    path: '/forms/:id/submissions',
+    path: '/forms/:formTemplateId/submissions',
     element: <FormsSubmissions/>,
     routeType: 'private',
   },


### PR DESCRIPTION
### Before
Submissions Page (with path `/forms/:id/submissions`)
![image](https://user-images.githubusercontent.com/24468466/200809845-4c60773b-49e4-4efc-ac93-6c8082037a9a.png)

### After
Submissions Page (with path `/forms/submissions/:formTemplateId`)
![image](https://user-images.githubusercontent.com/24468466/200809891-315c622e-6984-44d8-8655-6327e5a0f4ba.png)

### General Changes
continue implementing the submission list API on the Submissions page

### Detail Changes
1. replace the path of the Submissions page
2. replace the form dummy title and descriptions with the data from the detail form template API
3. show the dynamic columns and values on the Submissions page table 