### PR TITLE
Frontend Features -> Implement API for Dialog Export Form Submission

### DIFF
--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -537,7 +537,7 @@ const FormsSubmissions = () => {
       <DialogShareLink id={Number(formTemplateId)} />
 
       {/* DIALOG EXPORT */}
-      <DialogExport id={Number(formTemplateId)} />
+      <DialogExport id={Number(formTemplateId)} title={formTemplateDetail?.label ?? ''} />
 
       {/* DIALOG QR CODE */}
       <DialogQrCode id={Number(formTemplateId)} />

--- a/ui/src/services/formTemplate.js
+++ b/ui/src/services/formTemplate.js
@@ -116,3 +116,18 @@ export const postShareLinkFormTemplate = async (formTemplateId, inputSignal, inp
     else return error.response
   }
 }
+
+export const postExportFormSubmission = async (inputSignal, inputParams, inputAxiosPrivate) => {
+  try {
+    const { data } = await inputAxiosPrivate.post('/form/template/export',
+      inputParams,
+      { signal: inputSignal },
+      {responseType: 'arraybuffer'}
+    )
+    return data
+  } catch (error) {
+    if (error.message === 'canceled') return { status: 'Canceled' }
+    else if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}


### PR DESCRIPTION
### **Before**
Submissions' Page -> Button Download
<img width="1440" alt="Screenshot 2022-11-22 at 14 27 05" src="https://user-images.githubusercontent.com/60956215/203251662-8e84aa47-e9f7-4259-859c-8865c9baafa9.png">

### **After**
Submissions' Page -> Button Export
<img width="1440" alt="Screenshot 2022-11-22 at 14 27 43" src="https://user-images.githubusercontent.com/60956215/203251757-778d2d8d-40e8-46c9-8044-a652d074a385.png">


https://user-images.githubusercontent.com/60956215/203252236-6816af39-26d3-4902-9e55-cff1c1397795.mp4

### **General Changes**
- Adjustment on the `DialogExport` component

### **Detail Changes**
- Add `postExportFormSubmission` function (that calls an API to export file) to `formTemplate` services
- Implement postExportFormSubmission function to `handleButtonSendClick` at `DialogExport` component