### PR TITLE
Frontend revisions/page forms date picker not used by default

### DIFF
--- a/ui/src/components/DateRangeTimePicker/DateRangeTimePicker.jsx
+++ b/ui/src/components/DateRangeTimePicker/DateRangeTimePicker.jsx
@@ -56,7 +56,7 @@ const DateRangeTimePicker = (props) => {
   const [ startTimeInput, setStartTimeInput ] = useState(initialStartTimeInput)
   const [ endDateInput, setEndDateInput ] = useState(initialEndDateInput)
   const [ endTimeInput, setEndTimeInput ] = useState(initialEndTimeInput)
-  const [ selectedDateRangeItem, setSelectedDateRangeItem ] = useState(dateRangeList[0][2].title)
+  const [ selectedDateRangeItem, setSelectedDateRangeItem ] = useState('')
   const [ countDays, setCountDays ] = useState(0)
   const [ key, setKey ] = useState(0)
 
@@ -82,6 +82,13 @@ const DateRangeTimePicker = (props) => {
   }
 
   const handleDateRangeItemClick = (inputItem) => {
+    // when click item already selected, do unselected and reset value
+    if(inputItem.title === selectedDateRangeItem) {
+      setSelectedDateRangeItem('')
+      setTempValue([ '', '' ])
+      return
+    }
+
     setSelectedDateRangeItem(inputItem.title)
     setTempValue([ inputItem.startDate, inputItem.endDate ])
 
@@ -169,6 +176,17 @@ const DateRangeTimePicker = (props) => {
     endDateInput,
     endTimeInput
   ])
+
+  useEffect(() => {
+    // set selected range item when open date picker
+    if(value.length === 2 && value[1]) {
+      if(value[1].toString() === dateRangeList[0][0].endDate.toString()) {
+        const getTotalDay = moment(tempValue[1]).diff(tempValue[0], 'days') + 1
+        const findDateRange = dateRangeList[0].find(item => item.totalDay === getTotalDay)
+        setSelectedDateRangeItem(findDateRange ? findDateRange.title : '')
+      }
+    }
+  }, [value])
 
   return (
     <Stack direction='row'>

--- a/ui/src/components/DateRangeTimePicker/dateRangeTimePickerData.js
+++ b/ui/src/components/DateRangeTimePicker/dateRangeTimePickerData.js
@@ -61,16 +61,19 @@ export const dateRangeList = [
       title: 'Last 7 Days',
       startDate: moment().subtract(6, 'days').startOf('days').toDate(),
       endDate: moment().endOf('days').toDate(),
+      totalDay: 7,
     },
     {
       title: 'Last 14 Days',
       startDate: moment().subtract(13, 'days').startOf('days').toDate(),
       endDate: moment().endOf('days').toDate(),
+      totalDay: 14,
     },
     {
       title: 'Last 30 Days',
       startDate: moment().subtract(29, 'days').startOf('days').toDate(),
       endDate: moment().endOf('days').toDate(),
+      totalDay: 30,
     },
   ],
 ]

--- a/ui/src/pages/Forms/Forms.jsx
+++ b/ui/src/pages/Forms/Forms.jsx
@@ -142,10 +142,7 @@ const Forms = () => {
   const [ isFilterOn, setIsFilterOn ] = useState(false)
   const [ filters, setFilters ] = useState(initialFilters)
   const [ isDateRangeTimePickerOpen, setIsDateRangeTimePickerOpen ] = useState(false)
-  const [ dateRangeTimeValue, setDateRangeTimeValue ] = useState([ 
-    getLast30Days().startTime,
-    getLast30Days().endTime,
-  ])
+  const [ dateRangeTimeValue, setDateRangeTimeValue ] = useState(['', ''])
   // DATA GRID - SELECTION
   const [ selectionModel, setSelectionModel ] = useState([])
   // DELETE DIALOG


### PR DESCRIPTION
### **Before**
by default the open date picker choose last 30 days as default value
<img width="1440" alt="Screen Shot 2022-11-28 at 15 47 48" src="https://user-images.githubusercontent.com/22076215/204222708-ba8e3bc2-291f-4beb-b75c-aab0cc773cbc.png">

### **After**
now the open date picker dont have default value
<img width="1440" alt="Screen Shot 2022-11-28 at 15 52 27" src="https://user-images.githubusercontent.com/22076215/204222997-6ab6a719-f0dc-4dcb-995c-c006d1c7d6aa.png">

### **General Changes**
- revisions on forms date picker

### **Detail Changes**
- [x] add property `totalDay`
- [x] fix behavior select date range list on date picker
- [x] by default the forms show without filter date range