### PR TITLE
Frontend revisions/page submissions component dialog medias preview

### DIFF
--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
@@ -43,6 +43,7 @@ const DialogMediasPreview = (props) => {
     if (inputMediaObject?.mimeType?.includes('image/')) output = {
       component: 'img',
       src: inputMediaObject.url,
+      className: classes.mediaPreviewImage,
     }
     // EXCEL TYPE MEDIA
     else if (
@@ -50,12 +51,14 @@ const DialogMediasPreview = (props) => {
       inputMediaObject?.mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' 
     ) output = {
       component: 'iframe',
-      src: `https://view.officeapps.live.com/op/embed.aspx?src=${inputMediaObject.url}&embedded=true`,
+      src: `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(inputMediaObject.url)}&embedded=true`,
+      className: classes.mediaPreviewDocument,
     }
     // OTHER DOCUMENT TYPE MEDIA
     else if (inputMediaObject?.mimeType?.includes('application/')) output = {
       component: 'iframe',
-      src: `https://docs.google.com/gview?url=${inputMediaObject.url}&embedded=true`,
+      src: `https://docs.google.com/gview?url=${encodeURIComponent(inputMediaObject.url)}&embedded=true`,
+      className: classes.mediaPreviewDocument,
     }
 
     return output
@@ -135,7 +138,7 @@ const DialogMediasPreview = (props) => {
           component={getContentPropertyFromMediaObject(mediaList[activeStep]).component}
           src={getContentPropertyFromMediaObject(mediaList[activeStep]).src}
           alt=''
-          className={classes.mediaPreview}
+          className={getContentPropertyFromMediaObject(mediaList[activeStep]).className}
         />}
       </Stack>
 

--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
@@ -34,6 +34,32 @@ const DialogMediasPreview = (props) => {
 
   const [ mediaList, setMediaList ] = useState([])
   const [ activeStep, setActiveStep ] = useState(0)
+  
+  const getContentPropertyFromMediaObject = (inputMediaObject) => {
+    let output = {}
+
+    // SOURCE: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+    // IMAGE TYPE MEDIA
+    if (inputMediaObject?.mimeType?.includes('image/')) output = {
+      component: 'img',
+      src: inputMediaObject.url,
+    }
+    // EXCEL TYPE MEDIA
+    else if (
+      inputMediaObject?.mimeType === 'application/vnd.ms-excel' ||
+      inputMediaObject?.mimeType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' 
+    ) output = {
+      component: 'iframe',
+      src: `https://view.officeapps.live.com/op/embed.aspx?src=${inputMediaObject.url}&embedded=true`,
+    }
+    // OTHER DOCUMENT TYPE MEDIA
+    else if (inputMediaObject?.mimeType?.includes('application/')) output = {
+      component: 'iframe',
+      src: `https://docs.google.com/gview?url=${inputMediaObject.url}&embedded=true`,
+    }
+
+    return output
+  }
 
   const loadMediaFilesData = async (inputAbortController, inputIsMounted) => {
     const resultMediaFilesData = await postDetailMediaFiles(
@@ -106,8 +132,8 @@ const DialogMediasPreview = (props) => {
       >
         {mediaList.length > 0 &&
         <Box
-          component='img'
-          src={mediaList[activeStep].url}
+          component={getContentPropertyFromMediaObject(mediaList[activeStep]).component}
+          src={getContentPropertyFromMediaObject(mediaList[activeStep]).src}
           alt=''
           className={classes.mediaPreview}
         />}

--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
@@ -55,7 +55,10 @@ const DialogMediasPreview = (props) => {
       className: classes.mediaPreviewDocument,
     }
     // OTHER DOCUMENT TYPE MEDIA
-    else if (inputMediaObject?.mimeType?.includes('application/')) output = {
+    else if (
+      inputMediaObject?.mimeType?.includes('application/') || 
+      inputMediaObject?.mimeType?.includes('text/')
+    ) output = {
       component: 'iframe',
       src: `https://docs.google.com/gview?url=${encodeURIComponent(inputMediaObject.url)}&embedded=true`,
       className: classes.mediaPreviewDocument,

--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/dialogMediasPreviewUseStyles.js
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/dialogMediasPreviewUseStyles.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
   content: {
     backgroundColor: theme.palette.grey[900],
     maxHeight: 'calc(100vh - (2 * 96px))',
+    maxWidth: '100%',
   },
   mediaPreview: {
     height: '100%',

--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/dialogMediasPreviewUseStyles.js
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/dialogMediasPreviewUseStyles.js
@@ -17,7 +17,13 @@ const useStyles = makeStyles((theme) => ({
     maxHeight: 'calc(100vh - (2 * 96px))',
     maxWidth: '100%',
   },
-  mediaPreview: {
+  mediaPreviewDocument: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    backgroundColor: theme.palette.common.white,
+  },
+  mediaPreviewImage: {
     height: '100%',
     maxWidth: '100%',
     backgroundColor: theme.palette.common.white,


### PR DESCRIPTION
### Before
`DialogMediasPreview` component on the Submissions Page
![image](https://user-images.githubusercontent.com/24468466/204779684-6fdbf1f9-c08f-4bae-8b35-868a8870315b.png)

### After
`DialogMediasPreview` component on the Submissions Page
![image](https://user-images.githubusercontent.com/24468466/204779901-01c03685-b760-4a60-b51b-d9771e11e2f5.png)

### General Changes
- fix the file preview on the `DialogMediasPreview` component on the Submissions page

### Detail Changes
1. fix the file preview on the `DialogMediasPreview` component on the Submissions page by adding the `getContentPropertyFromMediaObject` function