### PR TITLE
Frontend revisions/error 401 handles

### DIFF
--- a/ui/src/components/DialogChangeGroup/DialogChangeGroup.jsx
+++ b/ui/src/components/DialogChangeGroup/DialogChangeGroup.jsx
@@ -33,8 +33,10 @@ import { putAssignGroupFormTemplate } from 'services/formTemplate'
 import useLayoutStyles from './dialogChangeGroupUseStyles'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -62,7 +64,7 @@ const DialogChangeGroup = (props) => {
       let response
       let message = {}
       
-      if(page === 'form-template') {
+      if (page === 'form-template') {
         response = await putAssignGroupFormTemplate(
           selectedItemId,
           abortController.signal,
@@ -71,7 +73,8 @@ const DialogChangeGroup = (props) => {
           },
           axiosPrivate,
         )
-      } else if (page === 'devices') {
+      } 
+      else if (page === 'devices') {
         response = await putAssignGroupDevices(
           selectedItemId,
           abortController.signal,
@@ -84,26 +87,23 @@ const DialogChangeGroup = (props) => {
 
       if (didSuccessfullyCallTheApi(response?.status)) {
         message = {
-          severity:'success',
-          title:'',
-          message:'Change group success'
+          severity: 'success',
+          title: '',
+          message: 'Change group success'
         }
 
         reloadData(abortController, true)
       } 
-      else if (!wasRequestCanceled(response?.status)) {
-        message = {
-          severity: 'error',
-          title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-          message: response?.data?.error?.message || 'Something went wrong',
-        }
+      else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+        message = getDefaultErrorMessage(response)
       }
 
       setSnackbarObject({
         open: true,
         ...message,
       })
-    } else {
+    } 
+    else {
       setGroupChecked(dataChecked)
     }
 
@@ -142,6 +142,9 @@ const DialogChangeGroup = (props) => {
     if (didSuccessfullyCallTheApi(resultGroupList.status) && inputIsMounted) {
       setGroupList(resultGroupList.data.list)
     }
+    else if (!wasRequestCanceled(resultGroupList?.status) && !wasAccessTokenExpired(resultGroupList.status)) {
+      setSnackbarObject(getDefaultErrorMessage(resultGroupList))
+    } 
   }
 
   // SIDE EFFECT FETCHING

--- a/ui/src/components/DialogQrCode/DialogQrCode.jsx
+++ b/ui/src/components/DialogQrCode/DialogQrCode.jsx
@@ -33,8 +33,10 @@ import useStyles from './dialogQrCodeUseStyles'
 import QRCode from 'qrcode'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi,
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -73,13 +75,9 @@ const DialogQrCode = (props) => {
 
     if (didSuccessfullyCallTheApi(response?.status)) {
       generateQR(response.data.value.link)
-    } else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    } 
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
 

--- a/ui/src/components/DialogShareLink/DialogShareLink.jsx
+++ b/ui/src/components/DialogShareLink/DialogShareLink.jsx
@@ -45,9 +45,11 @@ import { postShareFormTemplate, postShareLinkFormTemplate } from 'services/formT
 import useStyles from './dialogShareLinkUseStyles'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
   isEmailFormatValid, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -112,12 +114,8 @@ const DialogShareLink = (props) => {
           setReceivers([])
           setIsDialogFormOpen(false)
         } 
-        else if (!wasRequestCanceled(response?.status)) {
-          message = {
-            severity: 'error',
-            title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-            message: response?.data?.error?.message || 'Something went wrong',
-          }
+        else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+          message = getDefaultErrorMessage(response)
         }
       } 
       else {
@@ -166,14 +164,10 @@ const DialogShareLink = (props) => {
 
     if (didSuccessfullyCallTheApi(response?.status)) {
       setFormLink(response.data.value.link)
-    } else if (!wasRequestCanceled(response?.status)) {
+    } 
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
       setFormLink('')
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
 

--- a/ui/src/pages/Devices/DeviceFlyout/DeviceFlyout.jsx
+++ b/ui/src/pages/Devices/DeviceFlyout/DeviceFlyout.jsx
@@ -36,8 +36,10 @@ import useLayoutStyles from 'styles/layoutPrivate'
 
 // UTILITIES
 import { getExpandOrCollapseIcon } from 'utilities/component'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -99,12 +101,8 @@ const DevicesFlyout = (props) => {
 
       reloadData(abortController.signal, true)
     } 
-    else if (!wasRequestCanceled(response?.status)) {
-      message = {
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      }
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      message = getDefaultErrorMessage(response)
     }
 
     setSnackbarObject({

--- a/ui/src/pages/Devices/Devices.jsx
+++ b/ui/src/pages/Devices/Devices.jsx
@@ -42,11 +42,13 @@ import {
 import useLayoutStyles from './devicesUseStyles'
 
 // UTILITIES
+import { getDeviceStatusColor } from 'utilities/component'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
-import { getDeviceStatusColor } from 'utilities/component'
 
 const Devices = () => {
   const classes = useLayoutStyles()
@@ -210,13 +212,8 @@ const Devices = () => {
       setTableData(response.data.content)
       setTotalRow(response.data.totalElements)
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
 
     isDataGridLoading && setIsDataGridLoading(false)
@@ -253,13 +250,8 @@ const Devices = () => {
 
         setSelectionModel([])
       }
-      else if (!wasRequestCanceled(response?.status)) {
-        setSnackbarObject({
-          open: true,
-          severity: 'error',
-          title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-          message: response?.data?.error?.message || 'Something went wrong',
-        })
+      else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+        setSnackbarObject(getDefaultErrorMessage(response))
       }
     }
 

--- a/ui/src/pages/Devices/DialogAddOrEditDevice/DialogAddOrEditDevice.jsx
+++ b/ui/src/pages/Devices/DialogAddOrEditDevice/DialogAddOrEditDevice.jsx
@@ -34,8 +34,10 @@ import { putUpdateLabelDevices } from 'services/devices'
 import useLayoutStyles from 'styles/layoutPrivate'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -75,13 +77,8 @@ const DialogAddOrEditDevice = (props) => {
           reloadData(abortController.signal, true)
           handleClose()
         } 
-        else if (!wasRequestCanceled(response?.status)) {
-          setSnackbarObject({
-            open: true,
-            severity:'error',
-            title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-            message: response?.data?.error?.message || 'Something went wrong',
-          })
+        else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+          setSnackbarObject(getDefaultErrorMessage(response))
         }
       } 
       else {

--- a/ui/src/pages/Devices/DialogInvite/DialogInvite.jsx
+++ b/ui/src/pages/Devices/DialogInvite/DialogInvite.jsx
@@ -29,8 +29,10 @@ import useStyles from './dialogInviteUseStyles'
 import useLayoutStyles from 'styles/layoutPrivate'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -80,16 +82,10 @@ const DialogInvite = () => {
       })
       handleCloseDialog()
     }
-    else if (!wasRequestCanceled(response?.status)) {
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
       setIsLoading(false)
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
-
   }
 
   return (

--- a/ui/src/pages/Forms/Forms.jsx
+++ b/ui/src/pages/Forms/Forms.jsx
@@ -39,12 +39,14 @@ import {
 } from 'services/formTemplate'
 
 // UTILITIES
+import { convertDate } from 'utilities/date'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
   isFormatDateSearchValid, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
-import { convertDate } from 'utilities/date'
 
 const Forms = () => {
   // CONTEXT
@@ -160,13 +162,8 @@ const Forms = () => {
     if (didSuccessfullyCallTheApi(response?.status)) {
       navigate(`/forms/edit/${response.data.value.id}`)
     } 
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
 
     abortController.abort()
@@ -228,6 +225,9 @@ const Forms = () => {
       setTableData(response.data.content)
       setTotalRow(response.data.totalElements)
     }
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
+    }
 
     isDataGridLoading && setIsDataGridLoading(false)
   }
@@ -260,13 +260,8 @@ const Forms = () => {
 
         setSelectionModel([])
       } 
-      else if (!wasRequestCanceled(response?.status)) {
-        setSnackbarObject({
-          open: true,
-          severity:'error',
-          title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-          message: response?.data?.error?.message || 'Something went wrong',
-        })
+      else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+        setSnackbarObject(getDefaultErrorMessage(response))
       }
     }
 

--- a/ui/src/pages/FormsCreateOrEdit/FormsCreateOrEdit.jsx
+++ b/ui/src/pages/FormsCreateOrEdit/FormsCreateOrEdit.jsx
@@ -20,11 +20,16 @@ import Divider from '@mui/material/Divider'
 import Stack from '@mui/material/Stack'
 
 // SERVICES
-import { getDetailFormTemplate, putUpdateFormTemplate } from 'services/formTemplate'
+import { 
+  getDetailFormTemplate, 
+  putUpdateFormTemplate, 
+} from 'services/formTemplate'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -61,13 +66,8 @@ const FormsCreateOrEdit = () => {
       setListFields(addOtherKeyToFields)
       setIsFormLoading(false)
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
 
@@ -102,13 +102,8 @@ const FormsCreateOrEdit = () => {
         message:'Change have been save'
       })
     } 
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
 
     setHasFormChanged(false)

--- a/ui/src/pages/FormsSubmissions/DialogExport/DialogExport.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogExport/DialogExport.jsx
@@ -49,7 +49,8 @@ const DialogExport = (props) => {
     const abortController = new AbortController()
     setIsLoading(true)
 
-    if(fileFormat || fileFormat !== ''){
+    // TO DO: CHANGE PROMISE THEN CATCH WITH ASYNC AWAIT
+    if(fileFormat || fileFormat !== '') {
       postExportFormSubmission(abortController.signal, {
         templateId: id,
         option: fileFormat

--- a/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogMediasPreview/DialogMediasPreview.jsx
@@ -30,6 +30,14 @@ import { downloadFileFromUrl } from 'services/others'
 // STYLES
 import useStyles from './dialogMediasPreviewUseStyles'
 
+// UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
+import { 
+  didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
+  wasRequestCanceled,
+} from 'utilities/validation'
+
 const DialogMediasPreview = (props) => {
   const { mediasPreviewObject, setMediasPreviewObject } = props
 
@@ -84,12 +92,15 @@ const DialogMediasPreview = (props) => {
       axiosPrivate,
     )
 
-    if (resultMediaFilesData.status === 200 && inputIsMounted) {
+    if (didSuccessfullyCallTheApi(resultMediaFilesData.status) && inputIsMounted) {
       setMediaList(resultMediaFilesData.data.list)
 
       refreshIntervalRef.current = setInterval(() => {
         setRefreshKey(current => current+1)
       }, 4000)
+    }
+    else if (!wasRequestCanceled(resultMediaFilesData?.status) && !wasAccessTokenExpired(resultMediaFilesData.status)) {
+      setSnackbarObject(getDefaultErrorMessage(resultMediaFilesData))
     }
   }
 
@@ -105,13 +116,12 @@ const DialogMediasPreview = (props) => {
       mediaList[activeStep].name,
     )
 
-    if (resultDownloadFile.status !== 200 && resultDownloadFile.status !== 0) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: '',
-        message: 'Sorry, could not downlaod the file now',
-      })
+    if (
+      !didSuccessfullyCallTheApi(resultDownloadFile?.status) && 
+      !wasAccessTokenExpired(resultDownloadFile.status) && 
+      resultDownloadFile.status !== 0
+    ) {
+      setSnackbarObject(getDefaultErrorMessage(resultDownloadFile))
     }
   }
 

--- a/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
+++ b/ui/src/pages/FormsSubmissions/FormsSubmissions.jsx
@@ -12,6 +12,7 @@ import DialogQrCode from 'components/DialogQrCode/DialogQrCode'
 import LoadingPaper from 'components/LoadingPaper/LoadingPaper'
 
 // CONTEXTS
+import { AllPagesContext } from 'contexts/AllPagesContext'
 import { PrivateLayoutContext } from 'contexts/PrivateLayoutContext'
 
 // HOOKS
@@ -44,9 +45,16 @@ import useStyles from './formsSubmissionsUseStyles'
 
 // UTILITIES
 import { convertDate } from 'utilities/date'
+import { getDefaultErrorMessage } from 'utilities/object'
+import { 
+  didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
+  wasRequestCanceled,
+} from 'utilities/validation'
 
 const FormsSubmissions = () => {
   // CONTEXT
+  const { setSnackbarObject } = useContext(AllPagesContext)
   const { setIsDialogFormOpen } = useContext(PrivateLayoutContext)
 
   // STYLES
@@ -176,6 +184,9 @@ const FormsSubmissions = () => {
     if (resultFormTemplateDetail.status === 200 && inputIsMounted) {
       setFormTemplateDetail({ ...resultFormTemplateDetail.data.value })
     }
+    else if (!wasRequestCanceled(resultFormTemplateDetail?.status) && !wasAccessTokenExpired(resultFormTemplateDetail.status)) {
+      setSnackbarObject(getDefaultErrorMessage(resultFormTemplateDetail))
+    }
 
     setIsDataGridLoading(false)
   }
@@ -207,7 +218,7 @@ const FormsSubmissions = () => {
       axiosPrivate
     )
 
-    if (resultSubmissionList.status === 200 && inputIsMounted) {
+    if (didSuccessfullyCallTheApi(resultSubmissionList?.status) && inputIsMounted) {
       const submissionList = resultSubmissionList?.data?.content?.map(submissionItem => {
         return {
           id: submissionItem?.id,
@@ -223,6 +234,9 @@ const FormsSubmissions = () => {
 
       setRawTableData(submissionList)
       setTotalRow(resultSubmissionList?.data?.totalElements)
+    }
+    else if (!wasRequestCanceled(resultSubmissionList?.status) && !wasAccessTokenExpired(resultSubmissionList.status)) {
+      setSnackbarObject(getDefaultErrorMessage(resultSubmissionList))
     }
 
     setIsDataGridLoading(false)

--- a/ui/src/pages/FormsSubmissionsDetail/FormsSubmissionsDetail.jsx
+++ b/ui/src/pages/FormsSubmissionsDetail/FormsSubmissionsDetail.jsx
@@ -35,7 +35,12 @@ import { getSubmissionListDetail } from 'services/form'
 import useStyles from './formsSubmissionsDetailUseStyles'
 
 // UTILITIES
-import { didSuccessfullyCallTheApi, wasRequestCanceled } from 'utilities/validation'
+import { getDefaultErrorMessage } from 'utilities/object'
+import { 
+  didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
+  wasRequestCanceled, 
+} from 'utilities/validation'
 
 const FormsSubmissionsDetail = () => {
   const axiosPrivate = useAxiosPrivate()
@@ -61,15 +66,11 @@ const FormsSubmissionsDetail = () => {
       axiosPrivate
     )
 
-    if(didSuccessfullyCallTheApi(response?.status)) {
+    if (didSuccessfullyCallTheApi(response?.status)) {
       setSubmissionDetail(response?.data?.value)
-    } else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity:'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    } 
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
 
     setIsFormLoading(false)

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -45,7 +45,12 @@ import useStyles from './dialogAddOrEditGroupUseStyles'
 
 // UTILITIES
 import { capitalizeEachWord } from 'utilities/string'
-import { didSuccessfullyCallTheApi } from 'utilities/validation'
+import { getDefaultErrorMessage } from 'utilities/object'
+import { 
+  didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
+  wasRequestCanceled,
+} from 'utilities/validation'
 
 const DialogAddOrEditGroup = (props) => {
   const { 
@@ -139,6 +144,9 @@ const DialogAddOrEditGroup = (props) => {
           title: '',
           message: message,
         })
+      }
+      else if (!wasRequestCanceled(resultAddOrEditGroup?.status) && !wasAccessTokenExpired(resultAddOrEditGroup.status)) {
+        setSnackbarObject(getDefaultErrorMessage(resultAddOrEditGroup))
       }
     }
     // CANCEL BUTTON IS CLICKED

--- a/ui/src/pages/Groups/Groups.jsx
+++ b/ui/src/pages/Groups/Groups.jsx
@@ -29,7 +29,12 @@ import {
 } from 'services/group'
 
 // UTILITIES
-import { didSuccessfullyCallTheApi } from 'utilities/validation'
+import { getDefaultErrorMessage } from 'utilities/object'
+import { 
+  didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
+  wasRequestCanceled,
+} from 'utilities/validation'
 
 const Groups = () => {
   const initialColumns = [
@@ -158,6 +163,9 @@ const Groups = () => {
       setTableData(resultGroupList.data.content)
       setTotalRow(resultGroupList.data.totalElements)
     }
+    else if (!wasRequestCanceled(resultGroupList?.status) && !wasAccessTokenExpired(resultGroupList.status)) {
+      setSnackbarObject(getDefaultErrorMessage(resultGroupList))
+    }
 
     setMustReloadDataGrid(false)
   }
@@ -184,6 +192,9 @@ const Groups = () => {
           title: '',
           message: 'Successfully delete the selected group'
         })
+      }
+      else if (!wasRequestCanceled(resultDeleteGroup?.status) && !wasAccessTokenExpired(resultDeleteGroup.status)) {
+        setSnackbarObject(getDefaultErrorMessage(resultDeleteGroup))
       }
 
       abortController.abort()

--- a/ui/src/pages/Home/Chart/Chart.jsx
+++ b/ui/src/pages/Home/Chart/Chart.jsx
@@ -29,8 +29,10 @@ import useStyles from './chartUseStyles'
 // UTILITIES
 import { convertDate } from 'utilities/date'
 import moment from 'moment'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
-  didSuccessfullyCallTheApi, 
+  didSuccessfullyCallTheApi,
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -98,13 +100,8 @@ const Chart = (props) => {
         }
       }))
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
 

--- a/ui/src/pages/Home/Home.jsx
+++ b/ui/src/pages/Home/Home.jsx
@@ -25,8 +25,10 @@ import useStyles from './homeUseStyles'
 
 // UTILITIES
 import { getLast30Days } from 'utilities/date'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
   didSuccessfullyCallTheApi, 
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -67,15 +69,11 @@ const Home = () => {
         ]
       )
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
+
   const fetchFormList = async (abortController, inputIsMounted) => {
     const response = await postGetListFormTemplate(
       abortController.signal,
@@ -92,18 +90,15 @@ const Home = () => {
         ]
       )
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
+  
   useEffect(() => {
     let isMounted = true
     const abortController = new AbortController()
+
     fetchDeviceList(abortController.signal, isMounted)
     fetchFormList(abortController.signal, isMounted)
 

--- a/ui/src/pages/Home/Map/Map.jsx
+++ b/ui/src/pages/Home/Map/Map.jsx
@@ -30,8 +30,10 @@ import 'leaflet/dist/leaflet.css'
 
 // UTILITIES
 import moment from 'moment'
+import { getDefaultErrorMessage } from 'utilities/object'
 import { 
-  didSuccessfullyCallTheApi, 
+  didSuccessfullyCallTheApi,
+  wasAccessTokenExpired,
   wasRequestCanceled,
 } from 'utilities/validation'
 
@@ -80,13 +82,8 @@ const Map = (props) => {
       setSubmissionList(newSubmissionList)
       setBoundCoordinateList(newSubmissionList.map(item => [ item?.submit_location?.lat, item.submit_location?.lng ]))
     }
-    else if (!wasRequestCanceled(response?.status)) {
-      setSnackbarObject({
-        open: true,
-        severity: 'error',
-        title: response?.data?.error?.status?.replaceAll('_', ' ') || '',
-        message: response?.data?.error?.message || 'Something went wrong',
-      })
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
     }
   }
 

--- a/ui/src/pages/Settings/Settings.jsx
+++ b/ui/src/pages/Settings/Settings.jsx
@@ -21,7 +21,6 @@ import IconPassword from '@mui/icons-material/Password'
 // STYLES
 import useStyles from './settingsUseStyles'
 
-
 const Settings = () => {
   const classes = useStyles()
 

--- a/ui/src/pages/Settings/Updates/UpdatePassword.jsx
+++ b/ui/src/pages/Settings/Updates/UpdatePassword.jsx
@@ -30,9 +30,12 @@ import useStyles from '../settingsUseStyles'
 import useLayoutStyles from 'styles/layoutPrivate'
 
 // UTILITIES
+import { getDefaultErrorMessage } from 'utilities/object'
 import {
   didSuccessfullyCallTheApi,
-  doesObjectContainDesiredValue
+  doesObjectContainDesiredValue,
+  wasAccessTokenExpired,
+  wasRequestCanceled,
 } from 'utilities/validation'
 
 const UpdatePassword = () => {
@@ -123,13 +126,8 @@ const UpdatePassword = () => {
         })
       }
       // SHOW AN ERROR MESSAGE IF UNSUCCESSFULLY CALLING THE API
-      else {
-        setSnackbarObject({
-          open: true,
-          severity: 'error',
-          title: resultResetPasswordUser?.data?.error?.status?.replaceAll('_', ' ') || '',
-          message: resultResetPasswordUser?.data?.error?.message || 'Something went wrong',
-        })
+      else if (!wasRequestCanceled(resultResetPasswordUser?.status) && !wasAccessTokenExpired(resultResetPasswordUser.status)) {
+        setSnackbarObject(getDefaultErrorMessage(resultResetPasswordUser))
       }
 
       abortController.abort()

--- a/ui/src/utilities/object.js
+++ b/ui/src/utilities/object.js
@@ -1,0 +1,8 @@
+export const getDefaultErrorMessage = (inputResponse) => {
+  return {
+    open: true,
+    severity: 'error',
+    title: inputResponse?.data?.error?.status?.replaceAll('_', ' ') || '',
+    message: inputResponse?.data?.error?.message || 'Something went wrong',
+  }
+}

--- a/ui/src/utilities/validation.js
+++ b/ui/src/utilities/validation.js
@@ -36,6 +36,11 @@ export const isFormatDateSearchValid = (date) => {
   else return false
 }
 
+export const wasAccessTokenExpired = (inputStatus) => {
+  if (inputStatus === 401) return true
+  else return false
+}
+
 export const wasRequestCanceled = (inputStatus) => {
   if (inputStatus === 'Canceled') return true
   else return false


### PR DESCRIPTION
### Before
No UI changes

### After
No UI changes

### General Changes
- handle the error 401 condition for all components and pages that call the API

### Detail Changes
1. add `object` utility
2. add `wasAccessTokenExpired` function on the `validation` utility
3. handle the error 401 condition for all components and pages that call the API