### PR TITLE
Frontend features/loading progress on update profile settings

### DIFF
--- a/ui/src/pages/Settings/Settings.jsx
+++ b/ui/src/pages/Settings/Settings.jsx
@@ -33,6 +33,7 @@ const Settings = () => {
   const { breakpointType } = useContext(AllPagesContext)
 
   const [ currentTab, setCurrentTab ] = useState(0)
+  const [ isLoading, setIsLoading ] = useState(false)
   
   return (
     <>
@@ -67,9 +68,9 @@ const Settings = () => {
         height={0}
       >
         {/* MAIN CONTENT */}
-        <LoadingPaper className={classes.mainContent}>
-          {currentTab === 0 && (<UpdateProfile />)}
-          {currentTab === 1 && (<UpdatePassword />)}
+        <LoadingPaper className={classes.mainContent} isLoading={isLoading}>
+          {currentTab === 0 && (<UpdateProfile isLoading={isLoading} setIsLoading={setIsLoading}/>)}
+          {currentTab === 1 && (<UpdatePassword isLoading={isLoading} setIsLoading={setIsLoading} />)}
         </LoadingPaper>
       </Stack>
     </>

--- a/ui/src/pages/Settings/Updates/UpdatePassword.jsx
+++ b/ui/src/pages/Settings/Updates/UpdatePassword.jsx
@@ -38,7 +38,9 @@ import {
   wasRequestCanceled,
 } from 'utilities/validation'
 
-const UpdatePassword = () => {
+const UpdatePassword = (props) => {
+  const { isLoading, setIsLoading } = props
+
   const classes = useStyles()
   const layoutClasses = useLayoutStyles()
 
@@ -64,7 +66,6 @@ const UpdatePassword = () => {
   const [ isPasswordShown, setIsPasswordShown ] = useState(false)
   const [ isNewPasswordShown, setIsNewPasswordShown ] = useState(false)
   const [ isConfirmPasswordShown, setIsConfirmPasswordShown ] = useState(false)
-  const [ isLoading, setIsLoading ] = useState(false)
 
   const handleFormObjectChange = (inputKey, inputNewValue) => {
     setFormObject(current => {

--- a/ui/src/pages/Settings/Updates/UpdateProfile.jsx
+++ b/ui/src/pages/Settings/Updates/UpdateProfile.jsx
@@ -41,7 +41,9 @@ import {
   wasRequestCanceled,
 } from 'utilities/validation'
 
-const UpdateProfile = () => {
+const UpdateProfile = (props) => {
+  const { isLoading, setIsLoading } = props
+
   const classes = useStyles()
   const layoutClasses = useLayoutStyles()
 
@@ -67,7 +69,6 @@ const UpdateProfile = () => {
   const [initialLogo, setInitialLogo] = useState(auth?.user?.logo_url)
   const [ formObject, setFormObject ] = useState(initialFormObject)
   const [ formHelperObject, setFormHelperObject ] = useState(initialFormHelperObject)
-  const [ isLoading, setIsLoading ] = useState(false)
   const [selectedFile, setSelectedFile] = useState()
   const [preview, setPreview] = useState()
 


### PR DESCRIPTION
### **After**
after click submit button, loading will appear
<img width="1440" alt="Screen Shot 2022-12-12 at 13 14 55" src="https://user-images.githubusercontent.com/22076215/206965896-1715278f-85c1-4081-8078-25d450e27b5e.png">

### ** General Changes**
- add loading progress on settings profile

### **Detail Changes**
- [x] add loading progress on `update profile`
- [x] add loading progress on `update password`