### PR TITLE
Frontend revisions/create edit form template auto select header info

### DIFF
--- a/ui/src/contexts/PageFormsCreateOrEditContext.jsx
+++ b/ui/src/contexts/PageFormsCreateOrEditContext.jsx
@@ -12,7 +12,7 @@ const PageFormsCreateOrEditContextProvider = (props) => {
   // DRAG AND DROP
   const [listFields, setListFields] = useState([])
   const [listToolbox, setListToolbox] = useState(dataListComponents)
-  const [selectedFieldsId, setSelectedFieldsId] = useState('')
+  const [selectedFieldsId, setSelectedFieldsId] = useState(0) // 0 or string uid
   const [selectedFieldsType, setSelectedFieldsType] = useState('formHeader')
   // FORM
   const [formObject, setFormObject] = useState(initObjectForm)


### PR DESCRIPTION
### **Before**
when open the page create/edit form first time, header info not selected
<img width="1440" alt="Screen Shot 2022-12-19 at 08 49 31" src="https://user-images.githubusercontent.com/22076215/208329259-6fdb5781-4ac6-456d-91d9-82d114839871.png">

### **After**
when open the page create/edit form first time, header info auto selected
<img width="1440" alt="Screen Shot 2022-12-19 at 08 52 52" src="https://user-images.githubusercontent.com/22076215/208329266-c6cb58cf-ab55-4f0e-8d62-39a1b64dce34.png">

### **General Changes**
- fix bug page create/edit form

### **Detail Changes**
- change selectedFieldId default state to 0, 0 is header info id