### PR TITLE
Frontend fixes/pages submission and submission detail download file

### DIFF
--- a/ui/src/pages/FormsSubmissions/DialogExport/DialogExport.jsx
+++ b/ui/src/pages/FormsSubmissions/DialogExport/DialogExport.jsx
@@ -59,9 +59,13 @@ const DialogExport = (props) => {
         option: fileFormat
       }, axiosPrivate)
         .then((response) => {
+          let fileExtension
+          if (fileFormat === 'CSV') fileExtension = 'csv'
+          else if (fileFormat === 'EXCEL') fileExtension = 'xlsx'
+
           downloadFileFromFileObject(
             new Blob([response]),
-            `Form_Submissions${title ? `_${title}` : ''}.${fileFormat.toLowerCase()}`,
+            `Form_Submissions${title ? `_${title}` : ''}.${fileFormat.toLowerCase()}.${fileExtension}`,
           )
 
           setIsLoading(false)

--- a/ui/src/services/worx/form.js
+++ b/ui/src/services/worx/form.js
@@ -43,7 +43,10 @@ export const postExportSubmissionDetail = async (
     const response = await inputAxiosPrivate.post(
       '/form/export',
       inputBodyParams, 
-      { signal: inputSignal },
+      { 
+        responseType: 'arraybuffer',
+        signal: inputSignal, 
+      },
     )
 
     return response

--- a/ui/src/services/worx/formTemplate.js
+++ b/ui/src/services/worx/formTemplate.js
@@ -121,8 +121,10 @@ export const postExportFormSubmission = async (inputSignal, inputParams, inputAx
   try {
     const { data } = await inputAxiosPrivate.post('/form/template/export',
       inputParams,
-      { signal: inputSignal },
-      {responseType: 'arraybuffer'}
+      { 
+        responseType: 'arraybuffer',
+        signal: inputSignal, 
+      },
     )
     return data
   } catch (error) {


### PR DESCRIPTION
### Before
The downloaded file from the Submission Detail
![image](https://user-images.githubusercontent.com/24468466/208382924-2680fec1-a6f7-4818-8dce-9803aea344c4.png)

### After
The downloaded file from the Submission Detail
![image](https://user-images.githubusercontent.com/24468466/208382984-7512ea83-2f4f-4019-a608-a586410cfd4d.png)

### General Changes
- fix the download feature on the Submission Detail and Submission Detail pages

### Detail Changes
1. add the `responseType` header value on the `formTemplate` worx service
2. fix  the `responseType` header value on the `form` worx service
3. add the file extension value for the downloaded file on the `DialogExport` component on the Submissions page