### PR TITLE
Frontend fixes/component custom data grid section pagination zoom effect

### DIFF
--- a/ui/src/components/Customs/CustomDataGrid.jsx
+++ b/ui/src/components/Customs/CustomDataGrid.jsx
@@ -34,7 +34,7 @@ const CustomDataGrid = styled(({ className, componentsProps, ...props }) => (
                 '& .MuiList-root': {
                   zoom: values.zoomValue, // zoom
                 },
-              }
+              },
             },
           },
         },
@@ -160,15 +160,16 @@ const CustomDataGrid = styled(({ className, componentsProps, ...props }) => (
     },
     '& .MuiDataGrid-footerContainer .MuiTablePagination-select': {
       zoom: values.zoomValue,
-      fontSize: 14,
+      fontSize: 12,
+      height: 22,
     },
     '& .MuiDataGrid-footerContainer .MuiSelect-nativeInput': {
       zoom: values.zoomValue,
     },
     '& .MuiDataGrid-footerContainer .MuiSvgIcon-root': {
       zoom: values.zoomValue,
-    }
-  }
+    },
+  },
 }))
 
 export default CustomDataGrid


### PR DESCRIPTION
### Before
The Forms page when the zoom effect is applied
![image](https://user-images.githubusercontent.com/24468466/208618264-afaa47ba-a0b1-400c-9428-e658b67693fd.png)

### After
The Forms page when the zoom effect is applied
![image](https://user-images.githubusercontent.com/24468466/208618092-41f87f47-e1ca-4d98-b503-6c5cc9b67daf.png)

### General Changes
- fix the zoom effect visualization on the pagination section of the `CustomDataGrid` component

### Detail Changes
1. fix the zoom effect visualization on the pagination section of the `CustomDataGrid` component