### PR TITLE
Frontend revisions/page fill form input barcode with override manual

### DIFF
--- a/ui/src/pages/FillForm/InputForm.jsx
+++ b/ui/src/pages/FillForm/InputForm.jsx
@@ -1081,6 +1081,8 @@ const InputForm = (props) => {
               size='small'
               fullWidth
               className={`heightFitContent ${classes.barcodeTextField}`}
+              disabled={!item.allow_manual_override}
+              onChange={(event) => handleInputChange(item.id, item.type, getKeyValue(item.type), event.target.value)}
             />
 
             <IconButton
@@ -1091,7 +1093,7 @@ const InputForm = (props) => {
               <IconCameraAlt fontSize='small' />{isOnMediumLargeScreen() && ' Camera'}
             </IconButton>
 
-            {item.allow_manual_override && (<IconButton
+            <IconButton
               size='large'
               className={`${classes.buttonRedPrimary} buttonScanBarcode heightFitContent`}
               component='label'
@@ -1103,7 +1105,7 @@ const InputForm = (props) => {
                 type='file'
                 onChange={(event) => handleScanImage(event, item.id, item.type, item.barcode_type === '1d')}
               />
-            </IconButton>)}
+            </IconButton>
           </Stack>
 
           {formObjectError?.[item.id] && (


### PR DESCRIPTION
### **Before**
<img width="1440" alt="Screen Shot 2022-12-26 at 09 23 15" src="https://user-images.githubusercontent.com/22076215/209488035-a1408247-1c13-47a4-a352-c2c43b9c2087.png">

### **After**
<img width="1440" alt="Screen Shot 2022-12-26 at 09 20 36" src="https://user-images.githubusercontent.com/22076215/209488038-cb1486f1-de19-4fea-b068-c1f8dd05c077.png">

### **General Changes**
- implement override manual

### **Detail Changes**
- when override manual on checked, textfield barcode can be filled by typing