### PR TITLE
Frontend revisions/remove min and max textfield on create edit form

### DIFF
--- a/ui/src/pages/FormsCreateOrEdit/formsCreateOrEditConstants.js
+++ b/ui/src/pages/FormsCreateOrEdit/formsCreateOrEditConstants.js
@@ -22,8 +22,6 @@ export const dataListComponents = [
     id: uuid(),
     label: 'Text Field',
     description: 'Description',
-    min_length: 1,
-    max_length: 24,
     required: false,
     type: 'text',
     duplicateFrom: null,


### PR DESCRIPTION
### **after**
by default now min and max, value comes from BE
<img width="1440" alt="Screen Shot 2022-12-28 at 10 13 20" src="https://user-images.githubusercontent.com/22076215/209748524-4dd312ff-aac3-41b6-8e38-ae3147325a85.png">
