### PR TITLE
Revisions/page groups edit group

### DIFF
--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -27,7 +27,6 @@ import Input from '@mui/material/Input'
 import InputAdornment from '@mui/material/InputAdornment'
 import InputLabel from '@mui/material/InputLabel'
 import FormControl from '@mui/material/FormControl'
-import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
@@ -42,6 +41,7 @@ import IconFormatColorText from '@mui/icons-material/FormatColorText'
 
 // SERVICES
 import { postGetDeviceList } from 'services/worx/devices'
+import { postGetListFormTemplate } from 'services/worx/formTemplate'
 import { 
   postCreateGroup, 
   putEditGroup,
@@ -85,6 +85,7 @@ const DialogAddOrEditGroup = (props) => {
   const [ groupName, setGroupName ] = useState(initialFormObject.groupName)
   const [ groupColor, setGroupColor ] = useState(initialFormObject.groupColor)
   const [ deviceList, setDeviceList ] = useState([])
+  const [ formList, setFormList ] = useState([])
 
   const [ anchorEl, setAnchorEl ] = useState(null)
 
@@ -192,11 +193,33 @@ const DialogAddOrEditGroup = (props) => {
     }
   }
 
+  const fetchFormList = async (abortController, inputIsMounted) => {
+    let requestParams = {
+      size: 10000,
+      page: 0,
+    }
+
+    const response = await postGetListFormTemplate(
+      abortController.signal,
+      requestParams,
+      {},
+      axiosPrivate,
+    )
+
+    if(didSuccessfullyCallTheApi(response?.status) && inputIsMounted) {
+      setFormList(response.data.content)
+    }
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
+    }
+  }
+
   useEffect(() => {
     let isMounted = true
     const abortController = new AbortController()
 
     fetchDeviceList(abortController, isMounted)
+    fetchFormList(abortController, isMounted)
 
     return () => {
       isMounted = false

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -20,13 +20,20 @@ import CustomDialogTitle from 'components/DialogAddOrEdit/Customs/CustomDialogTi
 import useAxiosPrivate from 'hooks/useAxiosPrivate'
 
 // MUIS
+import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
+import Checkbox from '@mui/material/Checkbox'
 import Input from '@mui/material/Input'
 import InputAdornment from '@mui/material/InputAdornment'
 import InputLabel from '@mui/material/InputLabel'
 import FormControl from '@mui/material/FormControl'
+import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
 import Popover from '@mui/material/Popover'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
 // MUI ICONS
@@ -256,6 +263,36 @@ const DialogAddOrEditGroup = (props) => {
             />
           </FormControl>
         </Stack>
+
+        {/* DEVICES AUTOCOMPLETE */}
+        <Autocomplete
+          multiple
+          limitTags={2}
+          options={deviceList}
+          getOptionLabel={(option) => option.label}
+          className={layoutClasses.dialogAddOrEditFormControlContainer}
+          renderOption={(props, option, { selected }) => (
+            <ListItemButton 
+              {...props}
+              className={classes.autocompleteListItem}
+            >
+              {/* CHECKBOX */}
+              <ListItemIcon>
+                <Checkbox checked={selected}/>
+              </ListItemIcon>
+
+              {/* TEXT */}
+              <ListItemText primary={option.label}/>
+            </ListItemButton>
+          )}
+          renderInput={(params) => (
+            <TextField 
+              {...params} 
+              label='Device Names' 
+              placeholder='Device Names' 
+            />
+          )}
+        />
       </CustomDialogContent>
 
       {/* DIALOG ACTIONS */}

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -312,6 +312,36 @@ const DialogAddOrEditGroup = (props) => {
             />
           )}
         />
+
+        {/* FORMS AUTOCOMPLETE */}
+        <Autocomplete
+          multiple
+          limitTags={2}
+          options={formList}
+          getOptionLabel={(option) => option.label}
+          className={layoutClasses.dialogAddOrEditFormControlContainer}
+          renderOption={(props, option, { selected }) => (
+            <ListItemButton 
+              {...props}
+              className={classes.autocompleteListItem}
+            >
+              {/* CHECKBOX */}
+              <ListItemIcon>
+                <Checkbox checked={selected}/>
+              </ListItemIcon>
+
+              {/* TEXT */}
+              <ListItemText primary={option.label}/>
+            </ListItemButton>
+          )}
+          renderInput={(params) => (
+            <TextField 
+              {...params} 
+              label='Form Names' 
+              placeholder='Form Names' 
+            />
+          )}
+        />
       </CustomDialogContent>
 
       {/* DIALOG ACTIONS */}

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -34,6 +34,7 @@ import IconClose from '@mui/icons-material/Close'
 import IconFormatColorText from '@mui/icons-material/FormatColorText'
 
 // SERVICES
+import { postGetDeviceList } from 'services/worx/devices'
 import { 
   postCreateGroup, 
   putEditGroup,
@@ -76,6 +77,7 @@ const DialogAddOrEditGroup = (props) => {
 
   const [ groupName, setGroupName ] = useState(initialFormObject.groupName)
   const [ groupColor, setGroupColor ] = useState(initialFormObject.groupColor)
+  const [ deviceList, setDeviceList ] = useState([])
 
   const [ anchorEl, setAnchorEl ] = useState(null)
 
@@ -161,6 +163,39 @@ const DialogAddOrEditGroup = (props) => {
     setDataDialogEdit(null)
     setIsDialogAddOrEditOpen(false)
   }
+
+  const fetchDeviceList = async (abortController, isMounted) => {
+    let requestParams = {
+      page: 0,
+      size: 10000,
+    }
+
+    const response = await postGetDeviceList(
+      abortController.signal,
+      requestParams,
+      {},
+      axiosPrivate,
+    )
+
+    if (didSuccessfullyCallTheApi(response?.status) && isMounted) {
+      setDeviceList(response.data.content)
+    }
+    else if (!wasRequestCanceled(response?.status) && !wasAccessTokenExpired(response.status)) {
+      setSnackbarObject(getDefaultErrorMessage(response))
+    }
+  }
+
+  useEffect(() => {
+    let isMounted = true
+    const abortController = new AbortController()
+
+    fetchDeviceList(abortController, isMounted)
+
+    return () => {
+      isMounted = false
+      abortController.abort()
+    }
+  }, [])
 
   useEffect(() => {
     // UPDATE THE DIALOG FORM IF THE DIALOG IS ON EDIT MODE

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -189,11 +189,9 @@ const DialogAddOrEditGroup = (props) => {
       const selectedFormIdList = response.data.value.forms.map(item => item.id)
 
       const newSelectedDeviceList = deviceList.filter(item => selectedDeviceIdList.includes(item.id))
-      console.log('newSelectedDeviceList', newSelectedDeviceList)
       setSelectedDeviceList(newSelectedDeviceList)
 
       const newSelectedFormList = formList.filter(item => selectedFormIdList.includes(item.id))
-      console.log('newSelectedFormList', newSelectedFormList)
       setSelectedFormList(newSelectedFormList)
     }
   }
@@ -325,7 +323,7 @@ const DialogAddOrEditGroup = (props) => {
           limitTags={2}
           options={deviceList}
           getOptionLabel={(option) => option.label}
-          className={layoutClasses.dialogAddOrEditFormControlContainer}
+          className={classes.autocomplete}
           renderOption={(props, option, { selected }) => (
             <ListItemButton 
               {...props}
@@ -345,6 +343,7 @@ const DialogAddOrEditGroup = (props) => {
               {...params} 
               label='Device Names' 
               placeholder='Device Names' 
+              variant='standard'
             />
           )}
           value={selectedDeviceList}
@@ -358,7 +357,7 @@ const DialogAddOrEditGroup = (props) => {
           limitTags={2}
           options={formList}
           getOptionLabel={(option) => option.label}
-          className={layoutClasses.dialogAddOrEditFormControlContainer}
+          className={classes.autocomplete}
           renderOption={(props, option, { selected }) => (
             <ListItemButton 
               {...props}
@@ -378,6 +377,7 @@ const DialogAddOrEditGroup = (props) => {
               {...params} 
               label='Form Names' 
               placeholder='Form Names' 
+              variant='standard'
             />
           )}
           value={selectedFormList}

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -173,14 +173,12 @@ const DialogAddOrEditGroup = (props) => {
   }
 
   const fetchDeviceList = async (abortController, isMounted) => {
-    let requestParams = {
-      page: 0,
-      size: 10000,
-    }
-
     const response = await postGetDeviceList(
       abortController.signal,
-      requestParams,
+      {
+        size: 10000,
+        page: 0,
+      },
       {},
       axiosPrivate,
     )
@@ -194,14 +192,12 @@ const DialogAddOrEditGroup = (props) => {
   }
 
   const fetchFormList = async (abortController, inputIsMounted) => {
-    let requestParams = {
-      size: 10000,
-      page: 0,
-    }
-
     const response = await postGetListFormTemplate(
       abortController.signal,
-      requestParams,
+      {
+        size: 10000,
+        page: 0,
+      },
       {},
       axiosPrivate,
     )

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/DialogAddOrEditGroup.jsx
@@ -86,6 +86,8 @@ const DialogAddOrEditGroup = (props) => {
   const [ groupColor, setGroupColor ] = useState(initialFormObject.groupColor)
   const [ deviceList, setDeviceList ] = useState([])
   const [ formList, setFormList ] = useState([])
+  const [ selectedDeviceList, setSelectedDeviceList ] = useState([])
+  const [ selectedFormList, setSelectedFormList ] = useState([])
 
   const [ anchorEl, setAnchorEl ] = useState(null)
 
@@ -132,6 +134,8 @@ const DialogAddOrEditGroup = (props) => {
           {
             name: groupName,
             color: groupColor,
+            form_ids: selectedFormList.map(item => item.id),
+            device_ids: selectedDeviceList.map(item => item.id),
           },
           axiosPrivate,
         )
@@ -284,6 +288,7 @@ const DialogAddOrEditGroup = (props) => {
         </Stack>
 
         {/* DEVICES AUTOCOMPLETE */}
+        {dialogType === 'edit' &&
         <Autocomplete
           multiple
           limitTags={2}
@@ -311,9 +316,12 @@ const DialogAddOrEditGroup = (props) => {
               placeholder='Device Names' 
             />
           )}
-        />
+          value={selectedDeviceList}
+          onChange={(event, newValue) => setSelectedDeviceList(newValue)}
+        />}
 
         {/* FORMS AUTOCOMPLETE */}
+        {dialogType === 'edit' &&
         <Autocomplete
           multiple
           limitTags={2}
@@ -341,7 +349,9 @@ const DialogAddOrEditGroup = (props) => {
               placeholder='Form Names' 
             />
           )}
-        />
+          value={selectedFormList}
+          onChange={(event, newValue) => setSelectedFormList(newValue)}
+        />}
       </CustomDialogContent>
 
       {/* DIALOG ACTIONS */}

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/dialogAddOrEditGroupUseStyles.js
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/dialogAddOrEditGroupUseStyles.js
@@ -23,6 +23,9 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: '6px',
     cursor: 'pointer',
   },
+  autocomplete: {
+    marginTop: 12,
+  },
   autocompleteListItem: {
     padding: '0px 4px',
     '& .MuiListItemIcon-root': {

--- a/ui/src/pages/Groups/DialogAddOrEditGroup/dialogAddOrEditGroupUseStyles.js
+++ b/ui/src/pages/Groups/DialogAddOrEditGroup/dialogAddOrEditGroupUseStyles.js
@@ -1,6 +1,6 @@
 // MUI STYLES
 import { makeStyles } from '@mui/styles'
-          
+
 const useStyles = makeStyles((theme) => ({
   pickerStyle: {
     width: '18px',
@@ -23,6 +23,13 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: '6px',
     cursor: 'pointer',
   },
+  autocompleteListItem: {
+    padding: '0px 4px',
+    '& .MuiListItemIcon-root': {
+      minWidth: 'unset',
+      marginRight: 4,
+    },
+  },
 }))
-          
+
 export default useStyles

--- a/ui/src/services/worx/group.js
+++ b/ui/src/services/worx/group.js
@@ -39,6 +39,21 @@ export const getGroupList = async (inputSignal, inputAxiosPrivate) => {
   }
 }
 
+export const getGroupById = async (inputSignal, inputAxiosPrivate, inputId) => {
+  try {
+    const response = await inputAxiosPrivate.get(
+      `/groups/${inputId}`, 
+      { signal: inputSignal }
+    )
+
+    return response
+  } catch (error) {
+    if (error.message === 'canceled') return { status: 'Canceled' }
+    else if (!error.response) return { status: 'No Server Response' }
+    else return error.response
+  }
+}
+
 export const postCreateGroup = async (inputSignal, inputBodyParams, inputAxiosPrivate) => {
   try {
     const response = await inputAxiosPrivate.post(


### PR DESCRIPTION
### Before
Groups Page
![image](https://user-images.githubusercontent.com/24468466/213144473-82bfda77-1677-4cf3-9419-3f4eae194ffd.png)

### After
Groups Page
![image](https://user-images.githubusercontent.com/24468466/213144109-3088eff8-e6d1-4f52-9876-75acdc0bc3cd.png)

### General Changes
- change the UI of the `DialogAddOrEditGroup` component

### Detail Changes
1. add `getGroupById` function on the `group` worx service
2. change the UI of the `DialogAddOrEditGroup` component