### PR TITLE
Frontend revisions/bring back multiple delete

### DIFF
--- a/ui/src/components/DataGridFilters/DataGridFilters.jsx
+++ b/ui/src/components/DataGridFilters/DataGridFilters.jsx
@@ -228,6 +228,8 @@ DataGridFilters.defaultProps = {
   isWithDateTimePicker: false,
   // DOWNLOAD
   isDownloadButtonEnabled: false,
+  // DELETE
+  isDeleteButtonEnabled: false
 }
 
 DataGridFilters.propTypes = {

--- a/ui/src/components/DataGridFilters/DataGridFilters.jsx
+++ b/ui/src/components/DataGridFilters/DataGridFilters.jsx
@@ -18,6 +18,7 @@ import Typography from '@mui/material/Typography'
 
 // MUI ICONS
 import IconDateRange from '@mui/icons-material/DateRange'
+import IconDelete from '@mui/icons-material/Delete'
 import IconDownload from '@mui/icons-material/Download'
 import IconFilterAlt from '@mui/icons-material/FilterAlt'
 import IconSettings from '@mui/icons-material/Settings'
@@ -47,6 +48,9 @@ const DataGridFilters = (props) => {
     setIsFilterOn,
     // TEXT
     contentTitle,
+    // DELETE
+    isDeleteButtonEnabled,
+    handleDeleteButtonClick,
     // DOWNLOAD
     isDownloadButtonEnabled,
     handleDownloadButtonClick,
@@ -106,6 +110,20 @@ const DataGridFilters = (props) => {
           onClick={handleDownloadButtonClick}
         >
           <IconDownload/>
+        </IconButton>
+      </CustomTooltip>}
+
+      {/* DELETE ICON */}
+      {isDeleteButtonEnabled &&
+      <CustomTooltip 
+        title='Delete' 
+        placement='top'
+      >
+        <IconButton 
+          className={classes.iconButton}
+          onClick={handleDeleteButtonClick}
+        >
+          <IconDelete/>
         </IconButton>
       </CustomTooltip>}
 
@@ -229,6 +247,9 @@ DataGridFilters.propTypes = {
   setIsDateRangeTimePickerOpen: PropTypes.func,
   handleSelectDateRangePickerButtonClick: PropTypes.func,
   handleCancelDateRangePickerButtonClick: PropTypes.func,
+  // DELETE
+  isDeleteButtonEnabled: PropTypes.bool,
+  handleDeleteButtonClick: PropTypes.func,
   // DOWNLOAD
   isDownloadButtonEnabled: PropTypes.bool,
   handleDownloadButtonClick: PropTypes.func,

--- a/ui/src/pages/Devices/Devices.jsx
+++ b/ui/src/pages/Devices/Devices.jsx
@@ -295,6 +295,9 @@ const Devices = () => {
             setIsFilterOn={setIsFilterOn}
             // TEXT
             contentTitle='Device List'
+            // DELETE
+            isDeleteButtonEnabled={selectionModel.length > 0}
+            handleDeleteButtonClick={() => setDialogDeleteDevice({id: selectionModel})}
           />
 
           <DataGridTable

--- a/ui/src/pages/Groups/Groups.jsx
+++ b/ui/src/pages/Groups/Groups.jsx
@@ -252,6 +252,9 @@ const Groups = () => {
             setIsFilterOn={setIsFilterOn}
             // TEXT
             contentTitle='Group List'
+            // DELETE
+            isDeleteButtonEnabled={selectionModel.length > 0}
+            handleDeleteButtonClick={() => setDialogDeleteObject({ id: selectionModel[0] })}
           />
 
           <DataGridTable


### PR DESCRIPTION
### **After**
<img width="1440" alt="Screen Shot 2023-02-02 at 10 12 31" src="https://user-images.githubusercontent.com/22076215/216218633-39b4792f-7296-4ab5-b92b-89461c9ee394.png">
<img width="1440" alt="Screen Shot 2023-02-02 at 10 45 10" src="https://user-images.githubusercontent.com/22076215/216218646-c870aae6-5d53-4f52-ac83-732734a75bb7.png">
<img width="1440" alt="Screen Shot 2023-02-02 at 10 45 28" src="https://user-images.githubusercontent.com/22076215/216218657-556a6b55-cd0e-4121-8ea0-d76afc8879fc.png">

### **Detail Changes**
- [x]  bring back icon button delete on `data grid filters`
- [x]  bring back multiple delete forms
- [x]  bring back multiple delete devices
- [x]  bring back multiple delete groups