### PR TITLE
Frontend revisions/submissions page download submissions missing parameter

### DIFF
--- a/ui/src/pages/FormsSubmissions/SubmissionDetailFlyout/SubmissionDetailFlyout.jsx
+++ b/ui/src/pages/FormsSubmissions/SubmissionDetailFlyout/SubmissionDetailFlyout.jsx
@@ -106,7 +106,10 @@ const SubmissionDetailFlyout = (props) => {
 
     const resultDownload = await postExportSubmissionDetail(
       abortController.signal,
-      { form_id: submissionDetail.id },
+      { 
+        form_id: submissionDetail.id,
+        option: format.toUpperCase(), 
+      },
       axiosPrivate,
     )
 


### PR DESCRIPTION
### Before
No UI Changes

### After
No UI Changes

### General Changes
- add a missing parameter for the download submissions API call

### Detail Changes
1. add a missing parameter for the download submissions API call on the `SubmissionDetailFlyout` component on the Submissions page